### PR TITLE
To assist in extreme write load scenarios I've replaced UnixNano() me…

### DIFF
--- a/db.go
+++ b/db.go
@@ -119,6 +119,7 @@ type DB struct {
 	sstIdGenerator   *IDGenerator             // ID generator for SSTables
 	walIdGenerator   *IDGenerator             // ID generator for WAL files
 	txnIdGenerator   *IDGenerator             // ID generator for transactions
+	txnTSGenerator   *IDGenerator             // Generator for transaction timestamps
 	logChannel       chan string              // Log channel, instead of log file or standard output we log to a channel
 	idgs             *IDGeneratorState        // ID generator state
 	oldestActiveRead int64                    // Oldest active read timestamp
@@ -153,6 +154,7 @@ func Open(opts *Options) (*DB, error) {
 		opts:    opts,
 		txns:    atomic.Pointer[[]*Txn]{},
 		closeCh: make(chan struct{}),
+		txnTSGenerator: newIDGeneratorWithTimestamp(),
 	}
 
 	db.idgs = &IDGeneratorState{

--- a/flusher.go
+++ b/flusher.go
@@ -27,8 +27,7 @@ import (
 
 // Flusher is responsible for queuing and flushing memtables to disk
 type Flusher struct {
-	db *DB // The db instance
-
+	db        *DB          // The db instance
 	immutable *queue.Queue // Immutable queue for memtables
 	swapping  int32        // Atomic flag indicating if the flusher is swapping
 }

--- a/id_generator.go
+++ b/id_generator.go
@@ -18,6 +18,7 @@ package wildcat
 import (
 	"math"
 	"sync/atomic"
+	"time"
 )
 
 // The IDGenerator is a thread-safe utility for generating unique, monotonic IDs.
@@ -31,6 +32,13 @@ type IDGenerator struct {
 func newIDGenerator() *IDGenerator {
 	return &IDGenerator{
 		lastID: 0,
+	}
+}
+
+// newIDGeneratorWithTimestamp creates a new ID generator starting from current nanosecond
+func newIDGeneratorWithTimestamp() *IDGenerator {
+	return &IDGenerator{
+		lastID: time.Now().UnixNano(),
 	}
 }
 

--- a/txn.go
+++ b/txn.go
@@ -48,7 +48,7 @@ func (db *DB) Begin() *Txn {
 		ReadSet:   make(map[string]int64),
 		WriteSet:  make(map[string][]byte),
 		DeleteSet: make(map[string]bool),
-		Timestamp: time.Now().UnixNano(),
+		Timestamp: db.txnTSGenerator.nextID(), // Monotonic ordering and no timestamp collisions even under extreme load
 		Committed: false,
 		mutex:     sync.Mutex{},
 	}


### PR DESCRIPTION
To assist in extreme write load scenarios I've replaced UnixNano() method with a new id generator addition that atomically increments timestamps starting at when the db instance starts up.  This helps prevent nanosecond timestamp collisions, completely!