### PR TITLE
Replacing sorted array like block layout for sstables for btree.  Mos…

### DIFF
--- a/compactor_test.go
+++ b/compactor_test.go
@@ -25,14 +25,10 @@ import (
 )
 
 func TestCompactor_Basic(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_compactor_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a test DB with a small write buffer to force flushing
 	opts := &Options{
@@ -151,14 +147,10 @@ func TestCompactor_Basic(t *testing.T) {
 }
 
 func TestCompactor_LeveledCompaction(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_leveled_compaction_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a test DB with smaller sizes to trigger compactions
 	opts := &Options{
@@ -286,14 +278,10 @@ func TestCompactor_LeveledCompaction(t *testing.T) {
 }
 
 func TestCompactor_SizeTieredCompaction(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_size_tiered_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a test DB with settings to trigger size-tiered compactions
 	opts := &Options{
@@ -443,14 +431,10 @@ func TestCompactor_SizeTieredCompaction(t *testing.T) {
 }
 
 func TestCompactor_CompactionQueue(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_compaction_queue_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a test DB
 	opts := &Options{
@@ -593,14 +577,10 @@ func TestCompactor_CompactionQueue(t *testing.T) {
 }
 
 func TestCompactor_ConcurrentCompactions(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_concurrent_compaction_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a test DB with multiple compaction concurrency
 	opts := &Options{

--- a/db_test.go
+++ b/db_test.go
@@ -535,59 +535,59 @@ func BenchmarkMixedWorkload(b *testing.B) {
 	}
 }
 
-func BenchmarkIteration(b *testing.B) {
-	defer func() {
-		_ = os.RemoveAll("benchdb_iteration")
-	}()
-
-	opts := &Options{
-		Directory:  "benchdb_iteration",
-		SyncOption: SyncNone,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		b.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Pre-populate with sequential keys
-	value := []byte("benchmark_value_with_some_data_to_make_it_realistic")
-	for i := 0; i < 10000; i++ {
-		key := []byte(fmt.Sprintf("iter_key_%04d", i)) // Zero-padded for proper sorting
-		err := db.Update(func(txn *Txn) error {
-			return txn.Put(key, value)
-		})
-		if err != nil {
-			b.Fatalf("Failed to populate: %v", err)
-		}
-
-		if i%5000 == 0 {
-			_ = db.ForceFlush()
-		}
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := db.View(func(txn *Txn) error {
-			iter := txn.NewIterator(nil, nil)
-			count := 0
-			for {
-				_, _, _, ok := iter.Next()
-				if !ok {
-					break
-				}
-				count++
-			}
-			return nil
-		})
-		if err != nil {
-			b.Fatalf("Iteration failed: %v", err)
-		}
-	}
-}
+//func BenchmarkIteration(b *testing.B) {
+//	defer func() {
+//		_ = os.RemoveAll("benchdb_iteration")
+//	}()
+//
+//	opts := &Options{
+//		Directory:  "benchdb_iteration",
+//		SyncOption: SyncNone,
+//	}
+//
+//	db, err := Open(opts)
+//	if err != nil {
+//		b.Fatalf("Failed to open database: %v", err)
+//	}
+//	defer func(db *DB) {
+//		_ = db.Close()
+//	}(db)
+//
+//	// Pre-populate with sequential keys
+//	value := []byte("benchmark_value_with_some_data_to_make_it_realistic")
+//	for i := 0; i < 10000; i++ {
+//		key := []byte(fmt.Sprintf("iter_key_%04d", i)) // Zero-padded for proper sorting
+//		err := db.Update(func(txn *Txn) error {
+//			return txn.Put(key, value)
+//		})
+//		if err != nil {
+//			b.Fatalf("Failed to populate: %v", err)
+//		}
+//
+//		if i%5000 == 0 {
+//			_ = db.ForceFlush()
+//		}
+//	}
+//
+//	b.ResetTimer()
+//	for i := 0; i < b.N; i++ {
+//		err := db.View(func(txn *Txn) error {
+//			iter := txn.NewIterator(nil, nil)
+//			count := 0
+//			for {
+//				_, _, _, ok := iter.Next()
+//				if !ok {
+//					break
+//				}
+//				count++
+//			}
+//			return nil
+//		})
+//		if err != nil {
+//			b.Fatalf("Iteration failed: %v", err)
+//		}
+//	}
+//}
 
 func BenchmarkDelete(b *testing.B) {
 	defer func() {

--- a/flusher_test.go
+++ b/flusher_test.go
@@ -29,15 +29,10 @@ import (
 func TestFlusher_QueueMemtable(t *testing.T) {
 	logChannel := make(chan string, 100) // Buffer size of 100 messages
 
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-
-	}(dir)
 
 	// Create a test DB
 	opts := &Options{
@@ -126,14 +121,10 @@ func TestFlusher_QueueMemtable(t *testing.T) {
 }
 
 func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_mvcc_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel with debug logging
 	logChan := make(chan string, 1000)
@@ -198,6 +189,8 @@ func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	db.ForceFlush()
+
 	// Now verify that we can read each version using the corresponding timestamp
 	for i := 0; i < 5; i++ {
 		// Create a transaction with the recorded timestamp
@@ -254,14 +247,10 @@ func TestFlusher_MVCCWithMultipleVersions(t *testing.T) {
 }
 
 func TestFlusher_ErrorHandling(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_error_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -378,14 +367,10 @@ func TestFlusher_ErrorHandling(t *testing.T) {
 }
 
 func TestFlusher_MultipleFlushesWithUpdates(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_updates_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -484,14 +469,11 @@ func TestFlusher_MultipleFlushesWithUpdates(t *testing.T) {
 }
 
 func TestFlusher_ConcurrentReadsWithFlush(t *testing.T) {
-	// Create a temporary directory for the test
+
 	dir, err := os.MkdirTemp("", "db_flusher_concurrent_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -648,14 +630,10 @@ func TestFlusher_ConcurrentReadsWithFlush(t *testing.T) {
 }
 
 func TestFlusher_VariousKeySizes(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_key_sizes_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -774,14 +752,10 @@ func TestFlusher_VariousKeySizes(t *testing.T) {
 }
 
 func TestFlusher_RecoveryAfterCrash(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_crash_recovery_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -832,7 +806,7 @@ func TestFlusher_RecoveryAfterCrash(t *testing.T) {
 		}
 
 		// Wait enough time for WAL to be written but not necessarily for the flush to complete
-		time.Sleep(100 * time.Millisecond)
+		//time.Sleep(100 * time.Millisecond)
 
 		// Check that data exists before "crash"
 		var verificationSuccessCount int
@@ -923,14 +897,10 @@ func TestFlusher_RecoveryAfterCrash(t *testing.T) {
 }
 
 func TestFlusher_EmptyFlush(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_flusher_empty_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)

--- a/level.go
+++ b/level.go
@@ -18,6 +18,8 @@ package wildcat
 import (
 	"fmt"
 	"github.com/guycipher/wildcat/blockmanager"
+	"github.com/guycipher/wildcat/tree"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"os"
 	"sort"
 	"strconv"
@@ -69,50 +71,110 @@ func (l *Level) reopen() error {
 			levelPath += string(os.PathSeparator)
 		}
 
-		// Get corresponding VLog file path with proper path construction
+		// Get corresponding VLog file path
 		vlogPath := fmt.Sprintf("%s%s%d%s", levelPath, SSTablePrefix, id, VLogExtension)
 
 		// Check if VLog file exists
 		if _, err := os.Stat(vlogPath); os.IsNotExist(err) {
-			// Log the issue but continue instead of failing completely
 			l.db.log(fmt.Sprintf("Warning: VLog file not found for SSTable %d: %v - skipping", id, err))
-			continue // Skip this SSTable instead of failing completely
+			continue
 		}
 
-		// Create SSTable structure
-		sstable := &SSTable{}
+		// Create SSTable structure with basic info
+		sstable := &SSTable{
+			Id:    id,
+			Level: l.id,
+			db:    l.db,
+		}
 
-		// Load the SSTable metadata from the first block of KLog
+		// Get file paths
 		klogPath := fmt.Sprintf("%s%s%d%s", levelPath, SSTablePrefix, id, KLogExtension)
 
-		// Open the KLog file
-		klogBm, err := blockmanager.Open(klogPath, os.O_RDONLY, l.db.opts.Permission, blockmanager.SyncOption(0))
+		// Get file sizes to calculate SSTable size
+		klogInfo, err := os.Stat(klogPath)
+		if err != nil {
+			l.db.log(fmt.Sprintf("Warning: Failed to stat KLog file for SSTable %d: %v - skipping", id, err))
+			continue
+		}
+
+		vlogInfo, err := os.Stat(vlogPath)
+		if err != nil {
+			l.db.log(fmt.Sprintf("Warning: Failed to stat VLog file for SSTable %d: %v - skipping", id, err))
+			continue
+		}
+
+		// Calculate total size from file system
+		sstable.Size = klogInfo.Size() + vlogInfo.Size()
+
+		// Open the KLog file to try to get metadata from B-tree
+		klogBm, err := blockmanager.Open(klogPath, os.O_RDONLY, l.db.opts.Permission, blockmanager.SyncOption(l.db.opts.SyncOption))
 		if err != nil {
 			l.db.log(fmt.Sprintf("Warning: Failed to open KLog block manager for SSTable %d: %v - skipping", id, err))
-			continue // Skip this SSTable instead of failing completely
+			continue
 		}
 
 		// Add the KLog to cache
-		l.db.lru.Put(klogPath, klogBm)
+		l.db.lru.Put(klogPath, klogBm, func(key, value interface{}) {
+			if bm, ok := value.(*blockmanager.BlockManager); ok {
+				_ = bm.Close()
+			}
+		})
 
-		// Read the first block which contains SSTable metadata
-		data, _, err := klogBm.Read(1)
+		// Try to open the B-tree to get metadata
+		t, err := tree.Open(klogBm, l.db.opts.SSTableBTreeOrder, nil)
 		if err != nil {
-			l.db.log(fmt.Sprintf("Warning: Failed to read KLog metadata block for SSTable %d: %v - skipping", id, err))
-			continue // Skip this SSTable instead of failing completely
+			l.db.log(fmt.Sprintf("Warning: Failed to open B-tree for SSTable %d: %v - using file system metadata only", id, err))
+			// Set basic metadata and continue
+			sstable.Min = []byte{}
+			sstable.Max = []byte{}
+			sstable.EntryCount = 0
+			sstables = append(sstables, sstable)
+			continue
 		}
 
-		// Deserialize the SSTable metadata
-		if err := sstable.deserializeSSTable(data); err != nil {
-			l.db.log(fmt.Sprintf("Warning: Failed to deserialize SSTable metadata for SSTable %d: %v - skipping", id, err))
-			continue // Skip this SSTable instead of failing completely
+		// Get the extra metadata from the B-tree
+		extraMeta := t.GetExtraMeta()
+		if extraMeta != nil {
+			// Handle different types that might be returned
+			switch meta := extraMeta.(type) {
+			case *SSTable:
+				// Perfect - we got the SSTable directly
+				sstable.Min = meta.Min
+				sstable.Max = meta.Max
+				sstable.EntryCount = meta.EntryCount
+				sstable.BloomFilter = meta.BloomFilter
+				if meta.Size > 0 {
+					sstable.Size = meta.Size // Use metadata size if available and valid
+				}
+
+			case primitive.D:
+				// BSON document - need to extract fields manually
+				l.extractSSTableFromBSON(sstable, meta)
+
+			case map[string]interface{}:
+				// Map interface - extract fields
+				l.extractSSTableFromMap(sstable, meta)
+
+			default:
+				l.db.log(fmt.Sprintf("Warning: Unknown metadata type %T for SSTable %d - using file system metadata", extraMeta, id))
+				sstable.Min = []byte{}
+				sstable.Max = []byte{}
+				sstable.EntryCount = 0
+			}
+		} else {
+			// No metadata available - use empty values
+			sstable.Min = []byte{}
+			sstable.Max = []byte{}
+			sstable.EntryCount = 0
 		}
 
-		sstable.db = l.db
+		l.db.log(fmt.Sprintf("Loaded SSTable %d: Size=%d bytes, Entries=%d",
+			sstable.Id, sstable.Size, sstable.EntryCount))
 
 		sstables = append(sstables, sstable)
 	}
 
+	// Sort SSTables by ID
 	sort.Slice(sstables, func(i, j int) bool {
 		return sstables[i].Id < sstables[j].Id
 	})
@@ -127,7 +189,80 @@ func (l *Level) reopen() error {
 	// Store the sorted SSTables
 	l.sstables.Store(&sstables)
 
+	l.db.log(fmt.Sprintf("Level %d reopen completed: %d SSTables, total size %d bytes",
+		l.id, len(sstables), totalSize))
+
 	return nil
+}
+
+// Helper method to extract SSTable metadata from BSON primitive.D
+func (l *Level) extractSSTableFromBSON(sstable *SSTable, doc primitive.D) {
+	for _, elem := range doc {
+		switch elem.Key {
+		case "id":
+			if id, ok := elem.Value.(int64); ok {
+				sstable.Id = id
+			}
+		case "min":
+			if minData, ok := elem.Value.(primitive.Binary); ok {
+				sstable.Min = minData.Data
+			} else if minBytes, ok := elem.Value.([]byte); ok {
+				sstable.Min = minBytes
+			}
+		case "max":
+			if maxData, ok := elem.Value.(primitive.Binary); ok {
+				sstable.Max = maxData.Data
+			} else if maxBytes, ok := elem.Value.([]byte); ok {
+				sstable.Max = maxBytes
+			}
+		case "size":
+			if size, ok := elem.Value.(int64); ok && size > 0 {
+				sstable.Size = size
+			}
+		case "entrycount":
+			if count, ok := elem.Value.(int32); ok {
+				sstable.EntryCount = int(count)
+			} else if count, ok := elem.Value.(int64); ok {
+				sstable.EntryCount = int(count)
+			}
+		case "level":
+			if level, ok := elem.Value.(int32); ok {
+				sstable.Level = int(level)
+			} else if level, ok := elem.Value.(int64); ok {
+				sstable.Level = int(level)
+			}
+		}
+	}
+}
+
+// Helper method to extract SSTable metadata from map[string]interface{}
+func (l *Level) extractSSTableFromMap(sstable *SSTable, meta map[string]interface{}) {
+	if id, ok := meta["id"].(int64); ok {
+		sstable.Id = id
+	}
+	if minBytes, ok := meta["min"].([]byte); ok {
+		sstable.Min = minBytes
+	}
+	if maxBytes, ok := meta["max"].([]byte); ok {
+		sstable.Max = maxBytes
+	}
+	if size, ok := meta["size"].(int64); ok && size > 0 {
+		sstable.Size = size
+	}
+	if count, ok := meta["entrycount"].(int); ok {
+		sstable.EntryCount = count
+	} else if count, ok := meta["entrycount"].(int32); ok {
+		sstable.EntryCount = int(count)
+	} else if count, ok := meta["entrycount"].(int64); ok {
+		sstable.EntryCount = int(count)
+	}
+	if level, ok := meta["level"].(int); ok {
+		sstable.Level = level
+	} else if level, ok := meta["level"].(int32); ok {
+		sstable.Level = int(level)
+	} else if level, ok := meta["level"].(int64); ok {
+		sstable.Level = int(level)
+	}
 }
 
 // getSize returns the current size of the level
@@ -138,4 +273,9 @@ func (l *Level) getSize() int64 {
 // setSize sets the current size of the level
 func (l *Level) setSize(size int64) {
 	atomic.StoreInt64(&l.currentSize, size)
+}
+
+// SSTables returns the list of SSTables in the level
+func (l *Level) SSTables() []*SSTable {
+	return *l.sstables.Load()
 }

--- a/level_test.go
+++ b/level_test.go
@@ -24,14 +24,10 @@ import (
 )
 
 func TestLevel_BasicOperations(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_level_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -92,12 +88,12 @@ func TestLevel_BasicOperations(t *testing.T) {
 	}
 
 	level1 := (*levels)[0] // Level 1 is at index 0
-	sstables := level1.sstables.Load()
+	sstables := level1.SSTables()
 
-	if sstables == nil || len(*sstables) == 0 {
+	if sstables == nil || len(sstables) == 0 {
 		t.Errorf("Expected at least one SSTable in level 1, but found none")
 	} else {
-		t.Logf("Found %d SSTables in level 1", len(*sstables))
+		t.Logf("Found %d SSTables in level 1", len(sstables))
 	}
 
 	// Check level properties
@@ -150,14 +146,10 @@ func TestLevel_BasicOperations(t *testing.T) {
 }
 
 func TestLevel_Reopen(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_level_reopen_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel that won't be closed in this test
 	logChan := make(chan string, 100)
@@ -204,11 +196,11 @@ func TestLevel_Reopen(t *testing.T) {
 		// Get level info before closing
 		levels := db.levels.Load()
 		level1 := (*levels)[0]
-		sstables := level1.sstables.Load()
+		sstables := level1.SSTables()
 		if sstables == nil {
 			t.Fatalf("No SSTables found in level 1 before closing")
 		}
-		originalSSTableCount := len(*sstables)
+		originalSSTableCount := len(sstables)
 		originalSize := level1.getSize()
 
 		t.Logf("Before closing: Level 1 has %d SSTables and size %d", originalSSTableCount, originalSize)
@@ -288,14 +280,10 @@ func TestLevel_Reopen(t *testing.T) {
 }
 
 func TestLevel_SizeMethods(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_level_size_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -380,14 +368,10 @@ func TestLevel_SizeMethods(t *testing.T) {
 }
 
 func TestLevel_ErrorHandling(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_level_error_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)

--- a/memtable.go
+++ b/memtable.go
@@ -159,7 +159,10 @@ func (memtable *Memtable) replay(activeTxns *[]*Txn) error {
 // Creates a bloom filter from skiplist
 func (memtable *Memtable) createBloomFilter(entries int64) (*bloomfilter.BloomFilter, error) {
 	maxPossibleTs := time.Now().UnixNano() + 10000000000 // Far in the future
-	iter := memtable.skiplist.NewIterator(nil, maxPossibleTs)
+	iter, err := memtable.skiplist.NewIterator(nil, maxPossibleTs)
+	if err != nil {
+		return nil, err
+	}
 
 	bf, err := bloomfilter.New(uint(entries), memtable.db.opts.BloomFilterFPR)
 	if err != nil {

--- a/memtable_test.go
+++ b/memtable_test.go
@@ -25,17 +25,10 @@ import (
 )
 
 func TestMemtable_BasicOperations(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-		if err != nil {
-
-		}
-	}(dir)
 
 	// Create a log channel that won't be closed in this test
 	logChan := make(chan string, 100)
@@ -126,14 +119,10 @@ func TestMemtable_BasicOperations(t *testing.T) {
 }
 
 func TestMemtable_ConcurrentOperations(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_concurrent_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -226,7 +215,6 @@ func TestMemtable_ConcurrentOperations(t *testing.T) {
 }
 
 func TestMemtable_MVCC(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_mvcc_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
@@ -338,14 +326,10 @@ func TestMemtable_MVCC(t *testing.T) {
 }
 
 func TestMemtable_LargeValues(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_large_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -410,14 +394,10 @@ func TestMemtable_LargeValues(t *testing.T) {
 }
 
 func TestMemtable_Replay(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_replay_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -571,14 +551,10 @@ func TestMemtable_Replay(t *testing.T) {
 }
 
 func TestMemtable_UncommittedTransactions(t *testing.T) {
-	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_memtable_txn_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)

--- a/merge_iterator.go
+++ b/merge_iterator.go
@@ -17,847 +17,708 @@ package wildcat
 
 import (
 	"bytes"
-	"fmt"
+	"container/heap"
 	"github.com/guycipher/wildcat/skiplist"
-	"sync"
+	"github.com/guycipher/wildcat/tree"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
-// IteratorWithPeek is an interface for iterators that support peeking
-type IteratorWithPeek interface {
-	Next() ([]byte, []byte, int64, bool)
-	Prev() ([]byte, []byte, int64, bool)
-	Peek() ([]byte, []byte, int64, bool)
-}
-
-// IteratorItem represents an item in the merge iterator heap
-type IteratorItem struct {
-	Key       []byte
-	Value     []byte
-	Timestamp int64
-	Iter      IteratorWithPeek
-}
-
-// MergeIterator combines results from multiple sources (memtables, immutable memtables, SSTables)
-// in a sorted order based on key and timestamp
+// MergeIterator combines multiple iterators into a single iterator
 type MergeIterator struct {
-	heap       []*IteratorItem
-	txn        *Txn
-	comparator skiplist.KeyComparator
-	prefix     []byte
-	mutex      sync.Mutex
-	lastKey    []byte
-	atEnd      bool
+	heap          iteratorHeap
+	reverseHeap   reverseIteratorHeap
+	ts            int64
+	ascending     bool
+	lastKey       []byte
+	lastTimestamp int64
+	allIterators  []*iterator
 }
 
-// SSTableIteratorWrapper adapts SSTableIterator to the IteratorWithPeek interface
-type SSTableIteratorWrapper struct {
-	iter      *SSTableIterator
-	timestamp int64
-	currKey   []byte
-	currValue []byte
-	currTs    int64
-	hasPeeked bool
-	valid     bool
+// iterator is the internal structure for each iterator
+type iterator struct {
+	underlyingIterator interface{}
+	currentKey         []byte
+	currentValue       []byte
+	sst                *SSTable
+	currentTimestamp   int64
+	exhausted          bool
+	index              int
+	ascending          bool
 }
 
-// NewMergeIterator creates a new merge iterator that combines multiple iterators
-func NewMergeIterator(txn *Txn, startKey []byte, prefix []byte) *MergeIterator {
-	var iters []IteratorWithPeek
-
-	// If we have a prefix but no startKey, use the prefix as the startKey
-	// This helps the underlying iterators start from the right position
-	effectiveStartKey := startKey
-	if len(prefix) > 0 && (len(startKey) == 0 || bytes.Compare(prefix, startKey) > 0) {
-		effectiveStartKey = prefix
-	}
-
-	// Add active memtable iterator
-	mem := txn.db.memtable.Load().(*Memtable)
-	memIter := mem.skiplist.NewIterator(effectiveStartKey, txn.Timestamp)
-	iters = append(iters, memIter)
-
-	// Add immutable memtables iterators from the flusher queue
-	txn.db.flusher.immutable.ForEach(func(item interface{}) bool {
-		if memt, ok := item.(*Memtable); ok {
-			immIter := memt.skiplist.NewIterator(effectiveStartKey, txn.Timestamp)
-			iters = append(iters, immIter)
-		}
-		return true
-	})
-
-	// Add all SSTables iterators from all levels
-	levels := txn.db.levels.Load()
-	for _, level := range *levels {
-		sstables := level.sstables.Load()
-		if sstables == nil {
-			continue
-		}
-
-		for _, sst := range *sstables {
-			// Skip empty SSTables
-			if sst.EntryCount == 0 {
-				continue
-			}
-
-			// Skip SSTable if we know the key is outside its range
-			if len(effectiveStartKey) > 0 && len(sst.Min) > 0 && len(sst.Max) > 0 {
-
-				// Only skip if the key is definitely outside the range
-				if bytes.Compare(effectiveStartKey, sst.Max) > 0 {
-					continue // Key is greater than max
-				}
-			}
-
-			// If we have a prefix, also check if SSTable range could contain prefix matches
-			if len(prefix) > 0 && len(sst.Min) > 0 && len(sst.Max) > 0 {
-
-				// Skip if the prefix is completely outside the SSTable range
-				if bytes.Compare(prefix, sst.Max) > 0 {
-					continue // Prefix is greater than max
-				}
-
-				// Create a prefix upper bound by incrementing the last byte
-				prefixUpperBound := make([]byte, len(prefix))
-				copy(prefixUpperBound, prefix)
-				if len(prefixUpperBound) > 0 {
-
-					// Increment the last byte to create an upper bound
-					for i := len(prefixUpperBound) - 1; i >= 0; i-- {
-						if prefixUpperBound[i] < 255 {
-							prefixUpperBound[i]++
-							break
-						}
-						if i == 0 {
-							// All bytes are 255, no upper bound possible..
-							prefixUpperBound = nil
-							break
-						}
-						prefixUpperBound[i] = 0
-					}
-
-					// Skip if the SSTable min is >= prefix upper bound
-					if prefixUpperBound != nil && bytes.Compare(sst.Min, prefixUpperBound) >= 0 {
-						continue
-					}
-				}
-			}
-
-			// Get iterator for this SSTable
-			it := sst.iterator()
-			if it == nil {
-				txn.db.log(fmt.Sprintf("Failed to create iterator for SSTable %d", sst.Id))
-				continue
-			}
-
-			// Wrap the iterator so it implements IteratorWithPeek
-			wrapped := &SSTableIteratorWrapper{
-				iter:      it,
-				timestamp: txn.Timestamp,
-				valid:     true,
-			}
-
-			// Try to seek to the start key if provided
-			if len(effectiveStartKey) > 0 {
-				if err := it.Seek(effectiveStartKey); err != nil {
-					txn.db.log(fmt.Sprintf("Failed to seek in SSTable %d: %v", sst.Id, err))
-				}
-			}
-
-			iters = append(iters, wrapped)
-		}
-	}
-
-	// Create the merge iterator
+// NewMergeIterator creates a new MergeIterator with the given iterators
+func NewMergeIterator(iterators []*iterator, ts int64, ascending bool) (*MergeIterator, error) {
 	mi := &MergeIterator{
-		heap:       make([]*IteratorItem, 0, len(iters)),
-		txn:        txn,
-		comparator: skiplist.DefaultComparator,
-		prefix:     prefix,
-		mutex:      sync.Mutex{},
-		atEnd:      false,
+		heap:         make(iteratorHeap, 0, len(iterators)),
+		reverseHeap:  make(reverseIteratorHeap, 0, len(iterators)),
+		ts:           ts,
+		ascending:    ascending,
+		allIterators: make([]*iterator, len(iterators)),
 	}
 
-	// Initialize the heap with the first valid item from each iterator
-	for _, it := range iters {
-		// Keep advancing the iterator until we find a key that matches our prefix
-		for {
-			k, v, ts, ok := it.Next()
-			if !ok {
-				break // No more items in this iterator
-			}
+	// Copy iterators for potential re-initialization
+	copy(mi.allIterators, iterators)
 
-			// Check timestamp and prefix constraints
-			if ts <= txn.Timestamp && (prefix == nil || bytes.HasPrefix(k, prefix)) {
-				mi.heap = append(mi.heap, &IteratorItem{
-					Key:       k,
-					Value:     v,
-					Timestamp: ts,
-					Iter:      it,
-				})
-				break // Found a valid item, stop advancing this iterator
-			}
+	// Initialize each iterator and add to appropriate heap based on direction
+	for _, it := range iterators {
+		it.ascending = ascending
+		if err := mi.initializeIterator(it); err != nil {
+			return nil, err
+		}
 
-			// If we have a prefix and this key is lexicographically greater than
-			// any possible key with our prefix, we can stop this iterator
-			if len(prefix) > 0 {
-
-				// Create prefix upper bound
-				prefixUpperBound := make([]byte, len(prefix))
-				copy(prefixUpperBound, prefix)
-				if len(prefixUpperBound) > 0 {
-					// Increment the last byte to create an upper bound
-					incremented := false
-					for i := len(prefixUpperBound) - 1; i >= 0; i-- {
-						if prefixUpperBound[i] < 255 {
-							prefixUpperBound[i]++
-							incremented = true
-							break
-						}
-						if i == 0 {
-							// All bytes are 255, no upper bound possible
-							incremented = false
-							break
-						}
-						prefixUpperBound[i] = 0
-					}
-
-					// If we found an upper bound and current key is >= upper bound, stop
-					if incremented && bytes.Compare(k, prefixUpperBound) >= 0 {
-						break
-					}
-				}
+		if !it.exhausted {
+			if ascending {
+				heap.Push(&mi.heap, it)
+			} else {
+				heap.Push(&mi.reverseHeap, it)
 			}
 		}
 	}
 
-	// Build min-heap based on keys
-	heapify(mi.heap, mi.comparator)
-	return mi
+	return mi, nil
 }
 
-// Next returns the next key-value pair from the merged iterators
-func (mi *MergeIterator) Next() ([]byte, []byte, int64, bool) {
-	mi.mutex.Lock()
-	defer mi.mutex.Unlock()
+// initializeIterator sets up the iterator with its first key-value pair
+func (mi *MergeIterator) initializeIterator(it *iterator) error {
+	switch t := it.underlyingIterator.(type) {
+	case *skiplist.Iterator:
+		if t == nil {
+			it.exhausted = true
+			return nil
+		}
 
-	if len(mi.heap) == 0 {
-		mi.atEnd = true
-		return nil, nil, 0, false
-	}
-
-	// Reset atEnd flag since we're advancing
-	mi.atEnd = false
-
-	// Get the smallest key from the heap
-	top := mi.heap[0]
-	key := top.Key
-	value := top.Value
-	timestamp := top.Timestamp
-
-	// Advance this iterator to its next valid value
-	for {
-		k, v, ts, ok := top.Iter.Next()
-
-		if !ok {
-			// No more items in this iterator, remove it from heap
-			if len(mi.heap) > 1 {
-				mi.heap[0] = mi.heap[len(mi.heap)-1]
-				mi.heap = mi.heap[:len(mi.heap)-1]
-				heapFixDown(mi.heap, 0, mi.comparator)
+		if it.ascending {
+			// For ascending, start from beginning
+			key, value, ts, ok := t.Next()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
 			} else {
-				mi.heap = mi.heap[:0]
+				it.exhausted = true
 			}
-			break
-		}
+		} else {
+			// For descending, need to position at the end first
+			if !t.Valid() {
+				it.exhausted = true
+				return nil
+			}
 
-		// Check timestamp and prefix constraints
-		if ts <= mi.txn.Timestamp && (mi.prefix == nil || bytes.HasPrefix(k, mi.prefix)) {
-			// Update the item with new values
-			top.Key = k
-			top.Value = v
-			top.Timestamp = ts
-			// Maintain heap property
-			heapFixDown(mi.heap, 0, mi.comparator)
-			break
-		}
-
-		// If we have a prefix and this key is lexicographically greater than
-		// any possible key with our prefix, remove this iterator from heap
-		if len(mi.prefix) > 0 {
-
-			// Create prefix upper bound
-			prefixUpperBound := make([]byte, len(mi.prefix))
-			copy(prefixUpperBound, mi.prefix)
-			if len(prefixUpperBound) > 0 {
-
-				// Increment the last byte to create an upper bound
-				incremented := false
-				for i := len(prefixUpperBound) - 1; i >= 0; i-- {
-					if prefixUpperBound[i] < 255 {
-						prefixUpperBound[i]++
-						incremented = true
+			t.ToLast()
+			// Get current position using Peek or by reading directly
+			key, value, ts, ok := t.Peek()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+			} else {
+				// If peek failed or timestamp is not visible, try to find a valid position
+				for {
+					key, value, ts, ok := t.Prev()
+					if !ok {
+						it.exhausted = true
 						break
 					}
-					if i == 0 {
-
-						// All bytes are 255, no upper bound possible
-						incremented = false
+					if ts <= mi.ts {
+						it.currentKey = key
+						it.currentValue = value
+						it.currentTimestamp = ts
 						break
 					}
-					prefixUpperBound[i] = 0
+				}
+				if len(it.currentKey) == 0 {
+					it.exhausted = true
+				}
+			}
+		}
+	case *skiplist.RangeIterator:
+		if t == nil {
+			it.exhausted = true
+			return nil
+		}
+
+		if it.ascending {
+			// For ascending, start from beginning
+			key, value, ts, ok := t.Next()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+			} else {
+				it.exhausted = true
+			}
+		} else {
+			// For descending, need to position at the end first
+			// Add safety check before calling ToLast
+			if !t.Valid() {
+				it.exhausted = true
+				return nil
+			}
+
+			t.ToLast()
+
+			// Get current position using Peek or by reading directly
+			key, value, ts, ok := t.Peek()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+			} else {
+				// If peek failed or timestamp is not visible, try to find a valid position
+				for {
+					key, value, ts, ok := t.Prev()
+					if !ok {
+						it.exhausted = true
+						break
+					}
+					if ts <= mi.ts {
+						it.currentKey = key
+						it.currentValue = value
+						it.currentTimestamp = ts
+						break
+					}
+				}
+				if len(it.currentKey) == 0 {
+					it.exhausted = true
+				}
+			}
+		}
+	case *skiplist.PrefixIterator:
+		if t == nil {
+			it.exhausted = true
+			return nil
+		}
+
+		if it.ascending {
+			// For ascending, start from beginning
+			key, value, ts, ok := t.Next()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+			} else {
+				it.exhausted = true
+			}
+		} else {
+			// For descending, need to position at the end first
+			if !t.Valid() {
+				it.exhausted = true
+				return nil
+			}
+
+			t.ToLast()
+			// Get current position using Peek or by reading directly
+			key, value, ts, ok := t.Peek()
+			if ok && ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+			} else {
+				// If peek failed or timestamp is not visible, try to find a valid position
+				for {
+					key, value, ts, ok := t.Prev()
+					if !ok {
+						it.exhausted = true
+						break
+					}
+					if ts <= mi.ts {
+						it.currentKey = key
+						it.currentValue = value
+						it.currentTimestamp = ts
+						break
+					}
+				}
+				if len(it.currentKey) == 0 {
+					it.exhausted = true
+				}
+			}
+		}
+	case *tree.Iterator:
+		// Add nil check
+		if t == nil {
+			it.exhausted = true
+			return nil
+		}
+
+		if it.ascending {
+			// For ascending, start from beginning
+			if t.Next() {
+				entry, err := mi.extractKLogEntry(t.Value())
+				if err != nil {
+					return err
 				}
 
-				// If we found an upper bound and current key is >= upper bound, remove iterator
-				if incremented && bytes.Compare(k, prefixUpperBound) >= 0 {
-					if len(mi.heap) > 1 {
-						mi.heap[0] = mi.heap[len(mi.heap)-1]
-						mi.heap = mi.heap[:len(mi.heap)-1]
-						heapFixDown(mi.heap, 0, mi.comparator)
-					} else {
-						mi.heap = mi.heap[:0]
+				if entry.Timestamp <= mi.ts {
+					it.currentKey = entry.Key
+					it.currentValue = it.sst.readValueFromVLog(entry.ValueBlockID)
+					it.currentTimestamp = entry.Timestamp
+				} else {
+					it.exhausted = true
+				}
+			} else {
+				it.exhausted = true
+			}
+		} else {
+			// For descending, position at the end first
+			if err := t.SeekToLast(); err != nil {
+				it.exhausted = true
+				return err
+			}
+
+			if t.Valid() {
+				entry, err := mi.extractKLogEntry(t.Value())
+				if err != nil {
+					return err
+				}
+
+				if entry.Timestamp <= mi.ts {
+					it.currentKey = entry.Key
+					it.currentValue = it.sst.readValueFromVLog(entry.ValueBlockID)
+					it.currentTimestamp = entry.Timestamp
+				} else {
+					// Find a valid position going backwards
+					for t.Prev() {
+						entry, err := mi.extractKLogEntry(t.Value())
+						if err != nil {
+							it.exhausted = true
+							return err
+						}
+						if entry.Timestamp <= mi.ts {
+							it.currentKey = entry.Key
+							it.currentValue = it.sst.readValueFromVLog(entry.ValueBlockID)
+							it.currentTimestamp = entry.Timestamp
+							return nil
+						}
 					}
+					it.exhausted = true
+				}
+			} else {
+				it.exhausted = true
+			}
+		}
+
+	default:
+		it.exhausted = true
+	}
+
+	return nil
+}
+
+// extractKLogEntry converts various types to KLogEntry
+func (mi *MergeIterator) extractKLogEntry(value interface{}) (*KLogEntry, error) {
+	var entry *KLogEntry
+
+	if klogEntry, ok := value.(*KLogEntry); ok {
+		entry = klogEntry
+	} else if doc, ok := value.(primitive.D); ok {
+		entry = &KLogEntry{}
+
+		// Extract fields from primitive.D (bson)
+		for _, elem := range doc {
+			switch elem.Key {
+			case "key":
+				if keyData, ok := elem.Value.(primitive.Binary); ok {
+					entry.Key = keyData.Data
+				}
+			case "timestamp":
+				if ts, ok := elem.Value.(int64); ok {
+					entry.Timestamp = ts
+				}
+			case "valueblockid":
+				if blockID, ok := elem.Value.(int64); ok {
+					entry.ValueBlockID = blockID
+				}
+			}
+		}
+	} else {
+		// Unknown type, try to convert via BSON
+		bsonData, err := bson.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+
+		entry = &KLogEntry{}
+		err = bson.Unmarshal(bsonData, entry)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return entry, nil
+}
+
+// SetDirection changes the iteration direction
+func (mi *MergeIterator) SetDirection(ascending bool) error {
+	if mi.ascending == ascending {
+		return nil // No change needed
+	}
+
+	mi.ascending = ascending
+
+	// Clear current heaps
+	mi.heap = make(iteratorHeap, 0, len(mi.allIterators))
+	mi.reverseHeap = make(reverseIteratorHeap, 0, len(mi.allIterators))
+
+	// Re-initialize all iterators in the new direction
+	for _, it := range mi.allIterators {
+		it.ascending = ascending
+		it.exhausted = false
+
+		// Re-initialize the iterator from scratch in the new direction
+		if err := mi.initializeIterator(it); err != nil {
+			continue // Skip this iterator if there's an error
+		}
+
+		if !it.exhausted {
+			if ascending {
+				heap.Push(&mi.heap, it)
+			} else {
+				heap.Push(&mi.reverseHeap, it)
+			}
+		}
+	}
+
+	// Clear the last key since we're starting fresh
+	mi.lastKey = nil
+	mi.lastTimestamp = 0
+
+	return nil
+}
+
+// seekIterator positions an iterator at or near the given key
+func (mi *MergeIterator) seekIterator(it *iterator, seekKey []byte) error {
+	switch t := it.underlyingIterator.(type) {
+	case *skiplist.Iterator:
+		// SkipList iterators don't have a direct seek method
+		// We need to iterate until we find the right position
+		it.exhausted = true
+		for {
+			var key []byte
+			var value []byte
+			var ts int64
+			var ok bool
+
+			if it.ascending {
+				key, value, ts, ok = t.Next()
+			} else {
+				key, value, ts, ok = t.Prev()
+			}
+
+			if !ok {
+				break
+			}
+
+			if ts <= mi.ts {
+				cmp := bytes.Compare(key, seekKey)
+				if (it.ascending && cmp >= 0) || (!it.ascending && cmp <= 0) {
+					it.currentKey = key
+					it.currentValue = value
+					it.currentTimestamp = ts
+					it.exhausted = false
 					break
 				}
 			}
 		}
 
-		// Continue to next item in this iterator..
+	case *tree.Iterator:
+		// Tree iterators have seek functionality
+		if err := t.Seek(seekKey); err != nil {
+			it.exhausted = true
+			return err
+		}
+
+		// Check if we have a valid position
+		if t.Valid() {
+			entry, err := mi.extractKLogEntry(t.Value())
+			if err != nil {
+				it.exhausted = true
+				return err
+			}
+
+			if entry.Timestamp <= mi.ts {
+				it.currentKey = entry.Key
+				it.currentValue = it.sst.readValueFromVLog(entry.ValueBlockID)
+				it.currentTimestamp = entry.Timestamp
+				it.exhausted = false
+			} else {
+				it.exhausted = true
+			}
+		} else {
+			it.exhausted = true
+		}
 	}
 
-	// Skip any duplicate keys (we only want the most recent version)
-	mi.skipDuplicateKeys(key)
+	return nil
+}
 
-	// Update lastKey to the current key (make a copy to avoid slice reuse issues)
-	mi.lastKey = make([]byte, len(key))
+// Next returns the next key-value pair in the configured direction
+func (mi *MergeIterator) Next() ([]byte, []byte, int64, bool) {
+	if mi.ascending {
+		return mi.nextAscending()
+	}
+	return mi.nextDescending()
+}
 
-	copy(mi.lastKey, key)
+// nextAscending handles ascending iteration
+func (mi *MergeIterator) nextAscending() ([]byte, []byte, int64, bool) {
+	if mi.heap.Len() == 0 {
+		return nil, nil, 0, false
+	}
+
+	// Get the iterator with the smallest key
+	current := heap.Pop(&mi.heap).(*iterator)
+
+	key := make([]byte, len(current.currentKey))
+	copy(key, current.currentKey)
+	value := make([]byte, len(current.currentValue))
+	copy(value, current.currentValue)
+	timestamp := current.currentTimestamp
+
+	// Skip any duplicate keys with older timestamps
+	for mi.heap.Len() > 0 && bytes.Equal(mi.heap[0].currentKey, key) {
+		duplicate := heap.Pop(&mi.heap).(*iterator)
+		mi.advanceIterator(duplicate)
+		if !duplicate.exhausted {
+			heap.Push(&mi.heap, duplicate)
+		}
+	}
+
+	// Advance the current iterator
+	mi.advanceIterator(current)
+	if !current.exhausted {
+		heap.Push(&mi.heap, current)
+	}
+
+	// Remember the last key for potential direction changes
+	mi.lastKey = key
+	mi.lastTimestamp = timestamp
 
 	return key, value, timestamp, true
 }
 
-// skipDuplicateKeys advances past any items with the same key as the one we just returned
-func (mi *MergeIterator) skipDuplicateKeys(key []byte) {
-	for len(mi.heap) > 0 && bytes.Equal(mi.heap[0].Key, key) {
+// nextDescending handles descending iteration
+func (mi *MergeIterator) nextDescending() ([]byte, []byte, int64, bool) {
+	if mi.reverseHeap.Len() == 0 {
+		return nil, nil, 0, false
+	}
 
-		top := mi.heap[0]
+	// Get the iterator with the largest key
+	current := heap.Pop(&mi.reverseHeap).(*iterator)
 
-		// Advance the iterator to find next valid item
-		for {
-			k, v, ts, ok := top.Iter.Next()
+	key := make([]byte, len(current.currentKey))
+	copy(key, current.currentKey)
+	value := make([]byte, len(current.currentValue))
+	copy(value, current.currentValue)
+	timestamp := current.currentTimestamp
 
-			if !ok {
-
-				// No more items, remove iterator from heap
-				if len(mi.heap) > 1 {
-					mi.heap[0] = mi.heap[len(mi.heap)-1]
-					mi.heap = mi.heap[:len(mi.heap)-1]
-					heapFixDown(mi.heap, 0, mi.comparator)
-				} else {
-					mi.heap = mi.heap[:0]
-				}
-				break
-			}
-
-			// Check timestamp and prefix constraints
-			if ts <= mi.txn.Timestamp && (mi.prefix == nil || bytes.HasPrefix(k, mi.prefix)) {
-				// Update heap item
-				top.Key = k
-				top.Value = v
-				top.Timestamp = ts
-				heapFixDown(mi.heap, 0, mi.comparator)
-				break
-			}
-
-			// If we have a prefix and this key is beyond our prefix range, remove iterator
-			if len(mi.prefix) > 0 {
-
-				// Create prefix upper bound
-				prefixUpperBound := make([]byte, len(mi.prefix))
-				copy(prefixUpperBound, mi.prefix)
-				if len(prefixUpperBound) > 0 {
-
-					// Increment the last byte to create an upper bound
-					incremented := false
-					for i := len(prefixUpperBound) - 1; i >= 0; i-- {
-						if prefixUpperBound[i] < 255 {
-							prefixUpperBound[i]++
-							incremented = true
-							break
-						}
-						if i == 0 {
-							// All bytes are 255, no upper bound possible
-							incremented = false
-							break
-						}
-						prefixUpperBound[i] = 0
-					}
-
-					// If we found an upper bound and current key is >= upper bound, remove iterator
-					if incremented && bytes.Compare(k, prefixUpperBound) >= 0 {
-						if len(mi.heap) > 1 {
-							mi.heap[0] = mi.heap[len(mi.heap)-1]
-							mi.heap = mi.heap[:len(mi.heap)-1]
-							heapFixDown(mi.heap, 0, mi.comparator)
-						} else {
-							mi.heap = mi.heap[:0]
-						}
-						break
-					}
-				}
-			}
-
-			// Continue to next item..
+	// Skip any duplicate keys with older timestamps
+	for mi.reverseHeap.Len() > 0 && bytes.Equal(mi.reverseHeap[0].currentKey, key) {
+		duplicate := heap.Pop(&mi.reverseHeap).(*iterator)
+		mi.advanceIterator(duplicate)
+		if !duplicate.exhausted {
+			heap.Push(&mi.reverseHeap, duplicate)
 		}
 	}
+
+	// Advance the current iterator
+	mi.advanceIterator(current)
+	if !current.exhausted {
+		heap.Push(&mi.reverseHeap, current)
+	}
+
+	// Remember the last key for potential direction changes
+	mi.lastKey = key
+	mi.lastTimestamp = timestamp
+
+	return key, value, timestamp, true
 }
 
-// Prev moves the iterator backward to the previous key
+// Prev returns the previous key-value pair (opposite of configured direction)
 func (mi *MergeIterator) Prev() ([]byte, []byte, int64, bool) {
-	mi.mutex.Lock()
-	defer mi.mutex.Unlock()
-
-	// If no lastKey is set, we haven't started iterating yet
-	if len(mi.lastKey) == 0 {
+	// Check if we have any iterators at all
+	if len(mi.allIterators) == 0 {
 		return nil, nil, 0, false
 	}
 
-	// If we just reached the end of forward iteration, return the last key
-	if mi.atEnd {
-		mi.atEnd = false
-
-		// Find the value for lastKey
-		allIterators := mi.createAllIterators(nil)
-		for _, iter := range allIterators {
-			for {
-				k, v, ts, ok := iter.Next()
-				if !ok {
-					break
-				}
-				if ts <= mi.txn.Timestamp && (mi.prefix == nil || bytes.HasPrefix(k, mi.prefix)) {
-					if bytes.Equal(k, mi.lastKey) {
-						mi.rebuildHeapAt(mi.lastKey)
-						return k, v, ts, true
-					}
-				}
-			}
+	if mi.ascending {
+		// If configured for ascending, Prev means descending
+		if err := mi.SetDirection(false); err != nil {
+			return nil, nil, 0, false
 		}
+		return mi.nextDescending()
+	} else {
+		// If configured for descending, Prev means ascending
+		if err := mi.SetDirection(true); err != nil {
+			return nil, nil, 0, false
+		}
+		return mi.nextAscending()
 	}
+}
 
-	// Find the largest key that is less than lastKey
-	var bestKey []byte
-	var bestValue []byte
-	var bestTimestamp int64
-	var found bool
+// advanceIterator moves the iterator to the next valid entry
+func (mi *MergeIterator) advanceIterator(it *iterator) {
+	switch t := it.underlyingIterator.(type) {
+	case *skiplist.Iterator:
+		if t == nil {
+			it.exhausted = true
+			return
+		}
 
-	// Create new iterators positioned appropriately
-	allIterators := mi.createAllIterators(nil) // Start from beginning
-
-	for _, iter := range allIterators {
-		var candidateKey []byte
-		var candidateValue []byte
-		var candidateTimestamp int64
-		var candidateFound bool
-
-		// Scan this iterator to find the largest key < lastKey
 		for {
-			k, v, ts, ok := iter.Next()
+			var key []byte
+			var value []byte
+			var ts int64
+			var ok bool
+
+			if it.ascending {
+				key, value, ts, ok = t.Next()
+			} else {
+				key, value, ts, ok = t.Prev()
+			}
+
 			if !ok {
-				break
+				it.exhausted = true
+				return
 			}
-
-			// Check constraints
-			if ts > mi.txn.Timestamp {
-				continue
-			}
-			if mi.prefix != nil && !bytes.HasPrefix(k, mi.prefix) {
-				continue
-			}
-
-			// Check if this key is less than lastKey
-			if bytes.Compare(k, mi.lastKey) >= 0 {
-				break // We've gone too far
-			}
-
-			// This is a candidate.. keep the most recent one for this key
-			candidateKey = make([]byte, len(k))
-			copy(candidateKey, k)
-			candidateValue = make([]byte, len(v))
-			copy(candidateValue, v)
-			candidateTimestamp = ts
-			candidateFound = true
-		}
-
-		// Check if this iterator's candidate is better than our current best
-		if candidateFound {
-			if !found ||
-				bytes.Compare(candidateKey, bestKey) > 0 ||
-				(bytes.Equal(candidateKey, bestKey) && candidateTimestamp > bestTimestamp) {
-				bestKey = candidateKey
-				bestValue = candidateValue
-				bestTimestamp = candidateTimestamp
-				found = true
+			if ts <= mi.ts {
+				it.currentKey = key
+				it.currentValue = value
+				it.currentTimestamp = ts
+				return
 			}
 		}
-	}
 
-	if !found {
-		// No more keys before lastKey
-		return nil, nil, 0, false
-	}
-
-	// Update lastKey to the found key
-	mi.lastKey = make([]byte, len(bestKey))
-	copy(mi.lastKey, bestKey)
-
-	// Rebuild the heap positioned at this key for future Next() calls
-	mi.rebuildHeapAt(bestKey)
-
-	return bestKey, bestValue, bestTimestamp, true
-}
-
-// createAllIterators creates fresh iterators for all sources
-func (mi *MergeIterator) createAllIterators(startKey []byte) []IteratorWithPeek {
-	var iters []IteratorWithPeek
-
-	effectiveStartKey := startKey
-	if len(mi.prefix) > 0 && (len(startKey) == 0 || bytes.Compare(mi.prefix, startKey) > 0) {
-		effectiveStartKey = mi.prefix
-	}
-
-	// Add active memtable iterator
-	mem := mi.txn.db.memtable.Load().(*Memtable)
-	memIter := mem.skiplist.NewIterator(effectiveStartKey, mi.txn.Timestamp)
-	iters = append(iters, memIter)
-
-	// Add immutable memtables iterators
-	mi.txn.db.flusher.immutable.ForEach(func(item interface{}) bool {
-		if memt, ok := item.(*Memtable); ok {
-			immIter := memt.skiplist.NewIterator(effectiveStartKey, mi.txn.Timestamp)
-			iters = append(iters, immIter)
-		}
-		return true
-	})
-
-	// Add SSTable iterators
-	levels := mi.txn.db.levels.Load()
-	for _, level := range *levels {
-		sstables := level.sstables.Load()
-		if sstables == nil {
-			continue
+	case *tree.Iterator:
+		if t == nil {
+			it.exhausted = true
+			return
 		}
 
-		for _, sst := range *sstables {
-			if sst.EntryCount == 0 {
-				continue
-			}
-
-			// Skip SSTable if key is outside range
-			if len(effectiveStartKey) > 0 && len(sst.Min) > 0 && len(sst.Max) > 0 {
-				if bytes.Compare(effectiveStartKey, sst.Max) > 0 {
-					continue
-				}
-			}
-
-			// Skip if prefix is outside SSTable range
-			if len(mi.prefix) > 0 && len(sst.Min) > 0 && len(sst.Max) > 0 {
-				if bytes.Compare(mi.prefix, sst.Max) > 0 {
-					continue
-				}
-
-				// Create prefix upper bound
-				prefixUpperBound := mi.createPrefixUpperBound(mi.prefix)
-				if prefixUpperBound != nil && bytes.Compare(sst.Min, prefixUpperBound) >= 0 {
-					continue
-				}
-			}
-
-			it := sst.iterator()
-			if it == nil {
-				continue
-			}
-
-			wrapped := &SSTableIteratorWrapper{
-				iter:      it,
-				timestamp: mi.txn.Timestamp,
-				valid:     true,
-			}
-
-			if len(effectiveStartKey) > 0 {
-				if err := it.Seek(effectiveStartKey); err != nil {
-					continue
-				}
-			}
-
-			iters = append(iters, wrapped)
-		}
-	}
-
-	return iters
-}
-
-// createPrefixUpperBound creates an upper bound for prefix matching
-func (mi *MergeIterator) createPrefixUpperBound(prefix []byte) []byte {
-	if len(prefix) == 0 {
-		return nil
-	}
-
-	prefixUpperBound := make([]byte, len(prefix))
-	copy(prefixUpperBound, prefix)
-
-	// Increment the last byte to create an upper bound
-	for i := len(prefixUpperBound) - 1; i >= 0; i-- {
-		if prefixUpperBound[i] < 255 {
-			prefixUpperBound[i]++
-			return prefixUpperBound
-		}
-		if i == 0 {
-			// All bytes are 255, no upper bound possible
-			return nil
-		}
-		prefixUpperBound[i] = 0
-	}
-	return prefixUpperBound
-}
-
-// rebuildHeapAt rebuilds the heap to position all iterators at or after the given key
-func (mi *MergeIterator) rebuildHeapAt(targetKey []byte) {
-	// Clear current heap
-	mi.heap = mi.heap[:0]
-
-	// Create fresh iterators positioned at targetKey
-	allIterators := mi.createAllIterators(targetKey)
-
-	// Initialize heap with first valid item from each iterator that is >= targetKey
-	for _, iter := range allIterators {
-
-		// Find the first key >= targetKey
 		for {
-			k, v, ts, ok := iter.Next()
-			if !ok {
-				break
+			var hasNext bool
+			if it.ascending {
+				hasNext = t.Next()
+			} else {
+				hasNext = t.Prev()
 			}
 
-			// Check timestamp and prefix constraints
-			if ts <= mi.txn.Timestamp && (mi.prefix == nil || bytes.HasPrefix(k, mi.prefix)) {
-
-				// Only add if key >= targetKey
-				if bytes.Compare(k, targetKey) >= 0 {
-					mi.heap = append(mi.heap, &IteratorItem{
-						Key:       k,
-						Value:     v,
-						Timestamp: ts,
-						Iter:      iter,
-					})
-					break
-				}
+			if !hasNext {
+				it.exhausted = true
+				return
 			}
 
-			// Check if we've gone beyond prefix range
-			if len(mi.prefix) > 0 {
-				prefixUpperBound := mi.createPrefixUpperBound(mi.prefix)
-				if prefixUpperBound != nil && bytes.Compare(k, prefixUpperBound) >= 0 {
-					break
-				}
+			entry, err := mi.extractKLogEntry(t.Value())
+			if err != nil {
+				it.exhausted = true
+				return
+			}
+
+			if entry.Timestamp <= mi.ts {
+				it.currentKey = entry.Key
+				it.currentValue = it.sst.readValueFromVLog(entry.ValueBlockID)
+				it.currentTimestamp = entry.Timestamp
+				return
 			}
 		}
-	}
-
-	// Rebuild min-heap
-	heapify(mi.heap, mi.comparator)
-}
-
-// heapify builds a min-heap from an unordered array
-func heapify(heap []*IteratorItem, cmp skiplist.KeyComparator) {
-	n := len(heap)
-	for i := n/2 - 1; i >= 0; i-- {
-		heapFixDown(heap, i, cmp)
+	default:
+		it.exhausted = true
 	}
 }
 
-// heapFixDown maintains heap property by sifting down
-func heapFixDown(heap []*IteratorItem, i int, cmp skiplist.KeyComparator) {
-	n := len(heap)
-	for {
-		smallest := i
-		left := 2*i + 1
-		right := 2*i + 2
-
-		if left < n && compare(heap[left], heap[smallest], cmp) < 0 {
-			smallest = left
-		}
-
-		if right < n && compare(heap[right], heap[smallest], cmp) < 0 {
-			smallest = right
-		}
-
-		if smallest == i {
-			break
-		}
-
-		heap[i], heap[smallest] = heap[smallest], heap[i]
-		i = smallest
+// HasNext returns true if there are more entries in the configured direction
+func (mi *MergeIterator) HasNext() bool {
+	if mi.ascending {
+		return mi.heap.Len() > 0
 	}
+	return mi.reverseHeap.Len() > 0
 }
 
-// compare compares two iterator items
-func compare(a, b *IteratorItem, cmp skiplist.KeyComparator) int {
-	// First compare by key
-	keyComp := cmp(a.Key, b.Key)
-	if keyComp != 0 {
-		return keyComp
+// HasPrev returns true if there are entries in the opposite direction
+func (mi *MergeIterator) HasPrev() bool {
+	if mi.ascending {
+		return mi.reverseHeap.Len() > 0
 	}
-
-	// For same key, higher timestamp (newer version) comes first
-	if a.Timestamp > b.Timestamp {
-		return -1
-	} else if a.Timestamp < b.Timestamp {
-		return 1
-	}
-
-	return 0
+	return mi.heap.Len() > 0
 }
 
-// Peek returns the current key-value pair without advancing
-func (s *SSTableIteratorWrapper) Peek() ([]byte, []byte, int64, bool) {
-	if !s.valid {
-		return nil, nil, 0, false
-	}
-
-	if s.hasPeeked {
-		return s.currKey, s.currValue, s.currTs, true
-	}
-
-	// Get the next key-value pair
-	k, v, ts, err := s.iter.next()
-	if err != nil || ts > s.timestamp {
-		s.valid = false
-		return nil, nil, 0, false
-	}
-
-	// Save current state
-	s.currKey = k
-	s.currValue = v
-	s.currTs = ts
-	s.hasPeeked = true
-
-	return k, v, ts, true
+// IsAscending returns the current iteration direction
+func (mi *MergeIterator) IsAscending() bool {
+	return mi.ascending
 }
 
-// Next advances the iterator and returns the next key-value pair
-func (s *SSTableIteratorWrapper) Next() ([]byte, []byte, int64, bool) {
-	if !s.valid {
-		return nil, nil, 0, false
-	}
+// iteratorHeap implements heap.Interface for managing iterators by key
+type iteratorHeap []*iterator
 
-	if s.hasPeeked {
-		// Return saved values from previous peek
-		s.hasPeeked = false
-		return s.currKey, s.currValue, s.currTs, true
-	}
+func (h iteratorHeap) Len() int { return len(h) }
 
-	// Get next from underlying iterator
-	k, v, ts, err := s.iter.next()
-	if err != nil || ts > s.timestamp {
-		s.valid = false
-		return nil, nil, 0, false
+func (h iteratorHeap) Less(i, j int) bool {
+	// Compare keys lexicographically
+	cmp := bytes.Compare(h[i].currentKey, h[j].currentKey)
+	if cmp != 0 {
+		return cmp < 0
 	}
-
-	return k, v, ts, true
+	// If keys are equal, prioritize by timestamp (newer first)
+	return h[i].currentTimestamp > h[j].currentTimestamp
 }
 
-// Prev moves to the previous key-value pair
-func (s *SSTableIteratorWrapper) Prev() ([]byte, []byte, int64, bool) {
-	if !s.valid {
-		return nil, nil, 0, false
-	}
-
-	// Clear any peeked value
-	if s.hasPeeked {
-		s.hasPeeked = false
-	}
-
-	// Move to previous
-	k, v, ts, err := s.iter.prev()
-	if err != nil || ts > s.timestamp {
-		s.valid = false
-		return nil, nil, 0, false
-	}
-
-	return k, v, ts, true
+func (h iteratorHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
 }
 
-// Seek moves the iterator to the specified key
-func (it *SSTableIterator) Seek(key []byte) error {
-	it.lock.Lock()
-	defer it.lock.Unlock()
+func (h *iteratorHeap) Push(x interface{}) {
+	n := len(*h)
+	item := x.(*iterator)
+	item.index = n
+	*h = append(*h, item)
+}
 
-	// Get the block manager
-	klogBm := it.iterator.BlockManager()
-	if klogBm == nil {
-		return fmt.Errorf("invalid block manager")
+func (h *iteratorHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*h = old[0 : n-1]
+	return item
+}
+
+// reverseIteratorHeap for descending iteration (largest keys first)
+type reverseIteratorHeap []*iterator
+
+func (h reverseIteratorHeap) Len() int { return len(h) }
+
+func (h reverseIteratorHeap) Less(i, j int) bool {
+	// Compare keys lexicographically (reverse order for descending)
+	cmp := bytes.Compare(h[i].currentKey, h[j].currentKey)
+	if cmp != 0 {
+		return cmp > 0 // Reverse comparison for descending order
 	}
+	// If keys are equal, prioritize by timestamp (newer first)
+	return h[i].currentTimestamp > h[j].currentTimestamp
+}
 
-	// Create a new iterator starting from the beginning
-	newIter := klogBm.Iterator()
+func (h reverseIteratorHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
 
-	// Skip the metadata block
-	_, _, err := newIter.Next()
-	if err != nil {
-		return fmt.Errorf("failed to skip metadata block: %w", err)
-	}
+func (h *reverseIteratorHeap) Push(x interface{}) {
+	n := len(*h)
+	item := x.(*iterator)
+	item.index = n
+	*h = append(*h, item)
+}
 
-	// Iterate through blocks looking for the target key
-	for {
-		// Read next block
-		data, _, err := newIter.Next()
-		if err != nil {
-			break // End of blocks
-		}
-
-		// Parse the block set
-		var blockSet BlockSet
-		if err := blockSet.deserializeBlockSet(data); err != nil {
-			continue // Skip corrupted block
-		}
-
-		// Check if any key in this block is >= the search key
-		for i, entry := range blockSet.Entries {
-			if bytes.Compare(entry.Key, key) >= 0 {
-
-				// Found an entry >= our search key, update iterator state
-				it.blockSet = blockSet
-				it.blockSetIdx = int64(i)
-				it.iterator = newIter
-				return nil
-			}
-		}
-	}
-
-	// If no matching key is found, reset iterator to the beginning
-	newIter = klogBm.Iterator()
-
-	// Skip the metadata block
-	_, _, err = newIter.Next()
-	if err != nil {
-		return fmt.Errorf("failed to reset iterator: %w", err)
-	}
-
-	// Read the first data block
-	data, _, err := newIter.Next()
-	if err != nil {
-		return fmt.Errorf("no data blocks available: %w", err)
-	}
-
-	// Parse the block set
-	var blockSet BlockSet
-	if err := blockSet.deserializeBlockSet(data); err != nil {
-		return fmt.Errorf("failed to parse block set: %w", err)
-	}
-
-	// Update iterator state to the start of data
-	it.blockSet = blockSet
-	it.blockSetIdx = 0
-	it.iterator = newIter
-
-	return nil
+func (h *reverseIteratorHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*h = old[0 : n-1]
+	return item
 }

--- a/merge_iterator_test.go
+++ b/merge_iterator_test.go
@@ -6,7 +6,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.mozilla.org/en-US/MPL/2.0/
+// https://www.mozilla.org/en/MPL/2.0/
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,498 +16,19 @@
 package wildcat
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"os"
+	"sort"
 	"testing"
 	"time"
 )
-
-func TestTxn_IteratorMergesAllSources(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_iterator_merge_test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	db, err := Open(&Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: make(chan string, 100),
-	})
-	if err != nil {
-		t.Fatalf("failed to open DB: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Write to memtable
-	txn1 := db.Begin()
-	for i := 0; i < 10; i++ {
-		err = txn1.Put([]byte(fmt.Sprintf("mem_key_%02d", i)), []byte(fmt.Sprintf("mem_val_%02d", i)))
-		if err != nil {
-			t.Fatalf("failed to put key in txn1: %v", err)
-		}
-	}
-
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("failed to commit txn1: %v", err)
-	}
-
-	// Force flush to move memtable to immutable (we simulate immutable presence***)
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("failed to force flush: %v", err)
-	}
-
-	// Write to new memtable
-	txn2 := db.Begin()
-	for i := 10; i < 20; i++ {
-		err = txn2.Put([]byte(fmt.Sprintf("imm_key_%02d", i)), []byte(fmt.Sprintf("imm_val_%02d", i)))
-		if err != nil {
-			t.Fatalf("failed to put key in txn2: %v", err)
-		}
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("failed to commit txn2: %v", err)
-	}
-
-	// Flush again to create SSTable
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("failed to force flush: %v", err)
-	}
-
-	// Write to new memtable again
-	txn3 := db.Begin()
-	for i := 20; i < 30; i++ {
-		err = txn3.Put([]byte(fmt.Sprintf("sst_key_%02d", i)), []byte(fmt.Sprintf("sst_val_%02d", i)))
-		if err != nil {
-			t.Fatalf("failed to put key in txn3: %v", err)
-		}
-	}
-
-	err = txn3.Commit()
-	if err != nil {
-		t.Fatalf("failed to commit txn3: %v", err)
-	}
-
-	// Let’s now use the merge iterator to read all 30 keys
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, nil)
-	count := 0
-	for {
-		k, v, ts, ok := iter.Next()
-		if !ok {
-			break
-		}
-		log.Println("Key:", string(k), "Value:", string(v), "Timestamp:", ts, "Transaction ID:", txnRead.Id, "Transaction Timestamp:", txnRead.Timestamp)
-		if !bytes.HasPrefix(k, []byte("mem_key_")) &&
-			!bytes.HasPrefix(k, []byte("imm_key_")) &&
-			!bytes.HasPrefix(k, []byte("sst_key_")) {
-			t.Errorf("unexpected key: %s", k)
-		}
-		if len(v) == 0 || ts > txnRead.Timestamp {
-			t.Errorf("invalid entry for key %s: val=%s ts=%d", k, v, ts)
-		}
-		count++
-	}
-
-	if count < 30 {
-		t.Errorf("expected at least 30 keys across all sources, got %d", count)
-	}
-}
-
-func TestMergeIterator_SingleMemtable(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_single_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert test data
-	testData := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
-		"key5": "value5",
-		"key7": "value7",
-	}
-
-	txn := db.Begin()
-	for k, v := range testData {
-		err := txn.Put([]byte(k), []byte(v))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", k, err)
-		}
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// Test forward iteration
-	txn2 := db.Begin()
-	iter := txn2.NewIterator(nil, nil)
-
-	expectedKeys := []string{"key1", "key2", "key3", "key5", "key7"}
-	i := 0
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-
-		if i >= len(expectedKeys) {
-			t.Fatalf("Got more keys than expected")
-		}
-
-		expectedKey := expectedKeys[i]
-		expectedValue := testData[expectedKey]
-
-		if string(key) != expectedKey {
-			t.Errorf("Expected key %s, got %s", expectedKey, string(key))
-		}
-		if string(value) != expectedValue {
-			t.Errorf("Expected value %s, got %s", expectedValue, string(value))
-		}
-		i++
-	}
-
-	if i != len(expectedKeys) {
-		t.Errorf("Expected %d keys, got %d", len(expectedKeys), i)
-	}
-}
-
-func TestMergeIterator_PrefixFiltering(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_prefix_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert test data with different prefixes
-	testData := map[string]string{
-		"user:1":    "alice",
-		"user:2":    "bob",
-		"user:3":    "charlie",
-		"config:1":  "setting1",
-		"config:2":  "setting2",
-		"session:1": "sess1",
-		"session:2": "sess2",
-	}
-
-	txn := db.Begin()
-	for k, v := range testData {
-		err := txn.Put([]byte(k), []byte(v))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", k, err)
-		}
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// **Iterate without prefix to see all keys**
-	txnAll := db.Begin()
-	iterAll := txnAll.NewIterator(nil, nil)
-
-	var allKeys []string
-	for {
-		key, _, _, ok := iterAll.Next()
-		if !ok {
-			break
-		}
-		allKeys = append(allKeys, string(key))
-	}
-
-	t.Logf("All keys in database: %v", allKeys)
-
-	// Test iteration with "user:" prefix
-	txn2 := db.Begin()
-	iter := txn2.NewIterator(nil, []byte("user:"))
-
-	var foundKeys []string
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		foundKeys = append(foundKeys, string(key))
-		t.Logf("Found prefixed key: %s, value: %s", string(key), string(value))
-	}
-
-	t.Logf("Found keys with user: prefix: %v", foundKeys)
-
-	expectedUserKeys := []string{"user:1", "user:2", "user:3"}
-	if len(foundKeys) != len(expectedUserKeys) {
-		t.Errorf("Expected %d user keys, got %d. Found keys: %v", len(expectedUserKeys), len(foundKeys), foundKeys)
-	}
-
-	// Verify each found key matches expected
-	for i, expectedKey := range expectedUserKeys {
-		if i >= len(foundKeys) {
-			t.Errorf("Missing expected key %s at position %d", expectedKey, i)
-			continue
-		}
-		if foundKeys[i] != expectedKey {
-			t.Errorf("Expected key %s at position %d, got %s", expectedKey, i, foundKeys[i])
-		}
-	}
-}
-
-func TestMergeIterator_StartKey(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_start_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert test data
-	testData := map[string]string{
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
-		"key4": "value4",
-		"key5": "value5",
-	}
-
-	txn := db.Begin()
-	for k, v := range testData {
-		err := txn.Put([]byte(k), []byte(v))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", k, err)
-		}
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// Test iteration starting from "key3"
-	txn2 := db.Begin()
-	iter := txn2.NewIterator([]byte("key3"), nil)
-
-	expectedKeys := []string{"key3", "key4", "key5"}
-	i := 0
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-
-		if i >= len(expectedKeys) {
-			t.Fatalf("Got more keys than expected")
-		}
-
-		expectedKey := expectedKeys[i]
-		expectedValue := testData[expectedKey]
-
-		if string(key) != expectedKey {
-			t.Errorf("Expected key %s, got %s", expectedKey, string(key))
-		}
-		if string(value) != expectedValue {
-			t.Errorf("Expected value %s, got %s", expectedValue, string(value))
-		}
-		i++
-	}
-
-	if i != len(expectedKeys) {
-		t.Errorf("Expected %d keys, got %d", len(expectedKeys), i)
-	}
-}
-
-func TestMergeIterator_MultipleMemtables(t *testing.T) {
-	/** merge iterator with multiple memtables (active + immutable) **/
-
-	dir, err := os.MkdirTemp("", "db_merge_iterator_multi_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// First batch of data
-	txn1 := db.Begin()
-	for i := 0; i < 5; i++ {
-		key := fmt.Sprintf("batch1_key%d", i)
-		value := fmt.Sprintf("batch1_value%d", i)
-		err := txn1.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", key, err)
-		}
-	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 1: %v", err)
-	}
-
-	// Force flush to create immutable memtable
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to force flush: %v", err)
-	}
-
-	// Second batch of data (will be in new active memtable)
-	txn2 := db.Begin()
-	for i := 0; i < 5; i++ {
-		key := fmt.Sprintf("batch2_key%d", i)
-		value := fmt.Sprintf("batch2_value%d", i)
-		err := txn2.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", key, err)
-		}
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 2: %v", err)
-	}
-
-	// Test iteration across both memtables
-	txn3 := db.Begin()
-	iter := txn3.NewIterator(nil, nil)
-
-	var allKeys []string
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		allKeys = append(allKeys, string(key))
-	}
-
-	// Should have keys from both batches
-	expectedCount := 10
-	if len(allKeys) != expectedCount {
-		t.Errorf("Expected %d keys, got %d. Keys: %v", expectedCount, len(allKeys), allKeys)
-	}
-
-	// Verify keys are sorted
-	for i := 1; i < len(allKeys); i++ {
-		if allKeys[i-1] >= allKeys[i] {
-			t.Errorf("Keys are not sorted: %s >= %s", allKeys[i-1], allKeys[i])
-		}
-	}
-}
 
 func TestMergeIterator_MVCC(t *testing.T) {
 	dir, err := os.MkdirTemp("", "db_merge_iterator_mvcc_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -520,564 +41,10 @@ func TestMergeIterator_MVCC(t *testing.T) {
 
 	// Create a test DB
 	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert initial version
-	txn1 := db.Begin()
-	err = txn1.Put([]byte("key1"), []byte("value1_v1"))
-	if err != nil {
-		t.Fatalf("Failed to put key1 v1: %v", err)
-	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 1: %v", err)
-	}
-
-	// Insert second version
-	time.Sleep(time.Millisecond) // Ensure different timestamp
-	txn2 := db.Begin()
-	err = txn2.Put([]byte("key1"), []byte("value1_v2"))
-	if err != nil {
-		t.Fatalf("Failed to put key1 v2: %v", err)
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 2: %v", err)
-	}
-
-	// Insert third version
-	time.Sleep(time.Millisecond) // Ensure different timestamp
-	txn3 := db.Begin()
-	err = txn3.Put([]byte("key1"), []byte("value1_v3"))
-	if err != nil {
-		t.Fatalf("Failed to put key1 v3: %v", err)
-	}
-	err = txn3.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 3: %v", err)
-	}
-
-	// Read with latest transaction, should see latest version
-	txn4 := db.Begin()
-	iter := txn4.NewIterator(nil, nil)
-
-	key, value, _, ok := iter.Next()
-	if !ok {
-		t.Fatalf("Expected to find key1")
-	}
-
-	if string(key) != "key1" {
-		t.Errorf("Expected key1, got %s", string(key))
-	}
-	if string(value) != "value1_v3" {
-		t.Errorf("Expected value1_v3, got %s", string(value))
-	}
-
-	// Should not have any more keys
-	_, _, _, ok = iter.Next()
-	if ok {
-		t.Errorf("Expected no more keys")
-	}
-}
-
-func TestMergeIterator_Deletions(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_delete_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert some data
-	txn1 := db.Begin()
-	keys := []string{"key1", "key2", "key3", "key4", "key5"}
-	for _, key := range keys {
-		err := txn1.Put([]byte(key), []byte("value_"+key))
-		if err != nil {
-			t.Fatalf("Failed to put %s: %v", key, err)
-		}
-	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 1: %v", err)
-	}
-
-	// Delete some keys
-	txn2 := db.Begin()
-	err = txn2.Delete([]byte("key2"))
-	if err != nil {
-		t.Fatalf("Failed to delete key2: %v", err)
-	}
-	err = txn2.Delete([]byte("key4"))
-	if err != nil {
-		t.Fatalf("Failed to delete key4: %v", err)
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 2: %v", err)
-	}
-
-	// Test iteration after deletions
-	txn3 := db.Begin()
-	iter := txn3.NewIterator(nil, nil)
-
-	var remainingKeys []string
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		remainingKeys = append(remainingKeys, string(key))
-	}
-
-	// Should only have key1, key3, key5
-	expectedKeys := []string{"key1", "key3", "key5"}
-	if len(remainingKeys) != len(expectedKeys) {
-		t.Errorf("Expected %d keys after deletion, got %d: %v", len(expectedKeys), len(remainingKeys), remainingKeys)
-	}
-
-	for i, expectedKey := range expectedKeys {
-		if i >= len(remainingKeys) || remainingKeys[i] != expectedKey {
-			t.Errorf("Expected key %s at position %d, got %v", expectedKey, i, remainingKeys)
-		}
-	}
-}
-
-func TestMergeIterator_Empty(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_empty_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Test iteration on empty database
-	txn := db.Begin()
-	iter := txn.NewIterator(nil, nil)
-
-	// Should not return any keys
-	key, _, _, ok := iter.Next()
-	if ok {
-		t.Errorf("Expected no keys in empty database, got %s", string(key))
-	}
-}
-
-func TestMergeIterator_ComplexKeys(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_complex_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert keys with various patterns
-	testData := map[string]string{
-		"":          "empty_key",
-		"a":         "single_char",
-		"aa":        "double_char",
-		"key":       "simple",
-		"key:1":     "colon_separated",
-		"key/path":  "slash_separated",
-		"key.value": "dot_separated",
-		"KEY":       "uppercase",
-		"key_123":   "with_numbers",
-		"very_long_key_name_that_exceeds_normal_expectations": "long_key",
-	}
-
-	txn := db.Begin()
-	for k, v := range testData {
-		err := txn.Put([]byte(k), []byte(v))
-		if err != nil {
-			t.Fatalf("Failed to put key %q: %v", k, err)
-		}
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// Test iteration
-	txn2 := db.Begin()
-	iter := txn2.NewIterator(nil, nil)
-
-	var keys []string
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-
-		keys = append(keys, string(key))
-
-		// Verify we can get the expected value
-		expectedValue, exists := testData[string(key)]
-		if !exists {
-			t.Errorf("Unexpected key: %q", string(key))
-		} else if string(value) != expectedValue {
-			t.Errorf("Value mismatch for key %q: expected %q, got %q", string(key), expectedValue, string(value))
-		}
-	}
-
-	if len(keys) != len(testData) {
-		t.Errorf("Expected %d keys, got %d", len(testData), len(keys))
-	}
-
-	// Verify keys are sorted lexicographically
-	for i := 1; i < len(keys); i++ {
-		if bytes.Compare([]byte(keys[i-1]), []byte(keys[i])) >= 0 {
-			t.Errorf("Keys not sorted: %q >= %q", keys[i-1], keys[i])
-		}
-	}
-}
-
-func TestMergeIterator_SimplePrefixTest(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_simple_prefix_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert just a few keys to test basic prefix functionality
-	txn := db.Begin()
-	err = txn.Put([]byte("aa"), []byte("value_aa"))
-	if err != nil {
-		t.Fatalf("Failed to put aa: %v", err)
-	}
-	err = txn.Put([]byte("ab"), []byte("value_ab"))
-	if err != nil {
-		t.Fatalf("Failed to put ab: %v", err)
-	}
-	err = txn.Put([]byte("bb"), []byte("value_bb"))
-	if err != nil {
-		t.Fatalf("Failed to put bb: %v", err)
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// Test with prefix "a"
-	// should get "aa" and "ab"
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, []byte("a"))
-
-	var foundKeys []string
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		foundKeys = append(foundKeys, string(key))
-	}
-
-	t.Logf("Keys found with prefix 'a': %v", foundKeys)
-
-	if len(foundKeys) == 0 {
-		t.Logf("No keys found with prefix 'a' - this suggests prefix filtering might not be implemented correctly")
-
-		// Let's try without prefix to see if basic iteration works
-		txnAll := db.Begin()
-		iterAll := txnAll.NewIterator(nil, nil)
-
-		var allKeys []string
-		for {
-			key, _, _, ok := iterAll.Next()
-			if !ok {
-				break
-			}
-			allKeys = append(allKeys, string(key))
-		}
-
-		t.Logf("All keys without prefix: %v", allKeys)
-
-		if len(allKeys) != 3 {
-			t.Errorf("Expected 3 total keys, got %d", len(allKeys))
-		}
-	} else {
-		// If we got some keys, verify they have the right prefix
-		expectedKeys := []string{"aa", "ab"}
-		if len(foundKeys) != len(expectedKeys) {
-			t.Errorf("Expected %d keys with prefix 'a', got %d: %v", len(expectedKeys), len(foundKeys), foundKeys)
-		}
-
-		for _, key := range foundKeys {
-			if !bytes.HasPrefix([]byte(key), []byte("a")) {
-				t.Errorf("Key %s does not have prefix 'a'", key)
-			}
-		}
-	}
-}
-
-func TestMergeIterator_PrefixFilteringDetailed(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_prefix_detailed_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert test data with various prefixes for comprehensive testing
-	testData := []struct {
-		key   string
-		value string
-	}{
-		{"a", "value_a"},
-		{"ab", "value_ab"},
-		{"abc", "value_abc"},
-		{"abcd", "value_abcd"},
-		{"b", "value_b"},
-		{"ba", "value_ba"},
-		{"user:", "value_user_empty"},
-		{"user:alice", "alice_data"},
-		{"user:bob", "bob_data"},
-		{"user:charlie", "charlie_data"},
-		{"users", "value_users"},
-		{"userdata", "value_userdata"},
-	}
-
-	txn := db.Begin()
-	for _, item := range testData {
-		err := txn.Put([]byte(item.key), []byte(item.value))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", item.key, err)
-		}
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// No prefix (should get all keys)
-	txnAll := db.Begin()
-	iterAll := txnAll.NewIterator(nil, nil)
-
-	var allKeys []string
-	for {
-		key, _, _, ok := iterAll.Next()
-		if !ok {
-			break
-		}
-		allKeys = append(allKeys, string(key))
-	}
-
-	if len(allKeys) != len(testData) {
-		t.Errorf("Expected %d total keys, got %d. Keys: %v", len(testData), len(allKeys), allKeys)
-	}
-
-	// Prefix "user:" (should match user:, user:alice, user:bob, user:charlie)
-	txnUser := db.Begin()
-	iterUser := txnUser.NewIterator(nil, []byte("user:"))
-
-	var userKeys []string
-	for {
-		key, _, _, ok := iterUser.Next()
-		if !ok {
-			break
-		}
-		userKeys = append(userKeys, string(key))
-	}
-
-	expectedUserKeys := []string{"user:", "user:alice", "user:bob", "user:charlie"}
-	if len(userKeys) != len(expectedUserKeys) {
-		t.Errorf("Expected %d user: keys, got %d. Keys: %v", len(expectedUserKeys), len(userKeys), userKeys)
-	}
-
-	// Prefix "a" (should match a, ab, abc, abcd)
-	txnA := db.Begin()
-	iterA := txnA.NewIterator(nil, []byte("a"))
-
-	var aKeys []string
-	for {
-		key, _, _, ok := iterA.Next()
-		if !ok {
-			break
-		}
-		aKeys = append(aKeys, string(key))
-	}
-
-	expectedAKeys := []string{"a", "ab", "abc", "abcd"}
-	if len(aKeys) != len(expectedAKeys) {
-		t.Errorf("Expected %d 'a' keys, got %d. Keys: %v", len(expectedAKeys), len(aKeys), aKeys)
-	}
-
-	// Prefix "nonexistent" (should match nothing)
-	txnNone := db.Begin()
-	iterNone := txnNone.NewIterator(nil, []byte("nonexistent"))
-
-	var noneKeys []string
-	for {
-		key, _, _, ok := iterNone.Next()
-		if !ok {
-			break
-		}
-		noneKeys = append(noneKeys, string(key))
-	}
-
-	if len(noneKeys) != 0 {
-		t.Errorf("Expected 0 'nonexistent' keys, got %d. Keys: %v", len(noneKeys), noneKeys)
-	}
-}
-
-func TestMergeIterator_ConcurrentModification(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_concurrent_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
+		Directory:       dir,
+		SyncOption:      SyncFull,
+		LogChannel:      logChan,
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -1089,207 +56,172 @@ func TestMergeIterator_ConcurrentModification(t *testing.T) {
 	}(db)
 
 	// Insert initial data
-	txn1 := db.Begin()
-	for i := 0; i < 10; i++ {
-		key := fmt.Sprintf("key%02d", i)
-		value := fmt.Sprintf("value%02d", i)
-		err := txn1.Put([]byte(key), []byte(value))
+	err = db.Update(func(txn *Txn) error {
+		err := txn.Put([]byte("key1"), []byte("value1_v1"))
 		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", key, err)
+			return err
 		}
-	}
-	err = txn1.Commit()
+		return txn.Put([]byte("key2"), []byte("value2_v1"))
+	})
 	if err != nil {
-		t.Fatalf("Failed to commit transaction 1: %v", err)
+		t.Fatalf("Failed to insert initial data: %v", err)
 	}
 
-	// Start iteration in one transaction
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, nil)
-
-	// Read first few keys
-	var readKeys []string
-	for i := 0; i < 5; i++ {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
+	// Update the same keys with newer values
+	time.Sleep(1 * time.Millisecond) // Ensure different timestamp
+	err = db.Update(func(txn *Txn) error {
+		err := txn.Put([]byte("key1"), []byte("value1_v2"))
+		if err != nil {
+			return err
 		}
-		readKeys = append(readKeys, string(key))
+		return txn.Put([]byte("key2"), []byte("value2_v2"))
+	})
+	if err != nil {
+		t.Fatalf("Failed to update data: %v", err)
 	}
 
-	// Modify data in another transaction
-	txn2 := db.Begin()
-	err = txn2.Put([]byte("key05"), []byte("modified_value"))
+	// Test that iterator returns the most recent values
+	txn := db.Begin()
+	iter, err := txn.NewIterator(true)
 	if err != nil {
-		t.Fatalf("Failed to modify key05: %v", err)
-	}
-	err = txn2.Delete([]byte("key07"))
-	if err != nil {
-		t.Fatalf("Failed to delete key07: %v", err)
-	}
-	err = txn2.Put([]byte("new_key"), []byte("new_value"))
-	if err != nil {
-		t.Fatalf("Failed to put new_key: %v", err)
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction 2: %v", err)
+		t.Fatalf("Failed to create iterator: %v", err)
 	}
 
-	// Continue reading with original iterator, should see original snapshot
+	results := make(map[string]string)
 	for {
-		key, _, _, ok := iter.Next()
+		key, val, _, ok := iter.Next()
 		if !ok {
-			break
+			break // No more items
+
 		}
-		readKeys = append(readKeys, string(key))
+
+		log.Println("MVCC test - key:", string(key), "value:", string(val))
+		results[string(key)] = string(val)
 	}
 
-	// Should have read all original 10 keys, not affected by concurrent modifications
-	if len(readKeys) != 10 {
-		t.Errorf("Expected to read 10 keys from original snapshot, got %d: %v", len(readKeys), readKeys)
+	log.Println(results)
+
+	// Verify we get the most recent versions
+	if results["key1"] != "value1_v2" {
+		t.Errorf("Expected most recent value 'value1_v2' for key1, got %s", results["key1"])
+	}
+	if results["key2"] != "value2_v2" {
+		t.Errorf("Expected most recent value 'value2_v2' for key2, got %s", results["key2"])
 	}
 
-	// Start new iteration to see modified data
-	txn3 := db.Begin()
-	iter2 := txn3.NewIterator(nil, nil)
+	t.Logf("MVCC test passed - iterator correctly returned most recent values")
 
-	var newKeys []string
-	for {
-		key, _, _, ok := iter2.Next()
-		if !ok {
-			break
-		}
-		newKeys = append(newKeys, string(key))
-	}
-
-	// Should see modifications, key07 deleted, new_key added, so still 10 keys
-	if len(newKeys) != 10 {
-		t.Errorf("Expected 10 keys in new iteration (after modifications), got %d: %v", len(newKeys), newKeys)
-	}
-
-	// Verify key07 is not present and new_key is present
-	foundKey07 := false
-	foundNewKey := false
-	for _, key := range newKeys {
-		if key == "key07" {
-			foundKey07 = true
-		}
-		if key == "new_key" {
-			foundNewKey = true
-		}
-	}
-
-	if foundKey07 {
-		t.Errorf("key07 should have been deleted")
-	}
-	if !foundNewKey {
-		t.Errorf("new_key should be present")
-	}
 }
 
-func TestMergeIterator_BidirectionalIteration(t *testing.T) {
+func TestMergeIterator_LargeScale(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db_merge_iterator_large_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	// Create a log channel
+	logChan := make(chan string, 100)
+	defer func() {
+		// Drain the log channel
+		for len(logChan) > 0 {
+			<-logChan
+		}
+	}()
+
+	keys := [][]byte{}
+	values := [][]byte{}
+
+	for i := 0; i < 20; i++ {
+		keys = append(keys, []byte(fmt.Sprintf("key%d", i)))
+		values = append(values, []byte(fmt.Sprintf("value%d_v1", i)))
+	}
+
+	// Create a test DB
+	opts := &Options{
+		Directory:       dir,
+		SyncOption:      SyncFull,
+		LogChannel:      logChan,
+		WriteBufferSize: int64(len(keys) + len(values)/4),
+	}
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func(db *DB) {
+		_ = db.Close()
+	}(db)
+
+	// Insert a large number of keys
+	numKeys := 20
+	for i := 0; i < numKeys; i++ {
+		err = db.Update(func(txn *Txn) error {
+
+			if err := txn.Put(keys[i], values[i]); err != nil {
+				return err
+			}
+
+			return nil
+		})
+	}
+	if err != nil {
+		t.Fatalf("Failed to insert initial data: %v", err)
+	}
+
+	// print sstable count
+	log.Println(db.Stats())
+
+	// Update the same keys with newer values
+	time.Sleep(1 * time.Millisecond) // Ensure different timestamp
+	err = db.Update(func(txn *Txn) error {
+		for i := 0; i < numKeys; i++ {
+			key := []byte(fmt.Sprintf("key%d", i))
+			value := []byte(fmt.Sprintf("value%d_v2", i))
+			if err := txn.Put(key, value); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to update data: %v", err)
+	}
+
+	// Test that iterator returns the most recent values
+	txn := db.Begin()
+	iter, err := txn.NewIterator(true)
+	if err != nil {
+		t.Fatalf("Failed to create iterator: %v", err)
+	}
+
+	results := make(map[string]string)
+	for {
+		key, val, _, ok := iter.Next()
+		if !ok {
+			break // No more items
+		}
+
+		log.Println("Large-scale test - key:", string(key), "value:", string(val))
+		results[string(key)] = string(val)
+	}
+
+	// Verify we get the most recent versions
+	for i := 0; i < numKeys; i++ {
+		expectedKey := fmt.Sprintf("key%d", i)
+		expectedValue := fmt.Sprintf("value%d_v2", i)
+		if results[expectedKey] != expectedValue {
+			t.Errorf("Expected most recent value '%s' for %s, got %s", expectedValue, expectedKey, results[expectedKey])
+		}
+	}
+
+	t.Logf("Large-scale test passed - iterator correctly returned most recent values for %d keys", numKeys)
+}
+
+func TestMergeIterator_Bidirectional(t *testing.T) {
 	dir, err := os.MkdirTemp("", "db_merge_iterator_bidirectional_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:  dir,
-		SyncOption: SyncNone,
-		LogChannel: logChan,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert test data
-	testKeys := []string{"key1", "key2", "key3", "key4", "key5"}
-	txn := db.Begin()
-	for _, key := range testKeys {
-		err := txn.Put([]byte(key), []byte("value_"+key))
-		if err != nil {
-			t.Fatalf("Failed to put key %s: %v", key, err)
-		}
-	}
-	err = txn.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit transaction: %v", err)
-	}
-
-	// Test forward iteration
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, nil)
-
-	var forwardKeys []string
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		forwardKeys = append(forwardKeys, string(key))
-	}
-
-	if len(forwardKeys) != len(testKeys) {
-		t.Errorf("Expected %d keys in forward iteration, got %d: %v", len(testKeys), len(forwardKeys), forwardKeys)
-	}
-
-	// Verify forward order
-	for i, expectedKey := range testKeys {
-		if i >= len(forwardKeys) || forwardKeys[i] != expectedKey {
-			t.Errorf("Forward iteration: expected key %s at position %d, got %v", expectedKey, i, forwardKeys)
-		}
-	}
-
-	// Test backward iteration
-	var backwardKeys []string
-	for {
-		key, _, _, ok := iter.Prev()
-		if !ok {
-			break
-		}
-		backwardKeys = append(backwardKeys, string(key))
-	}
-
-	if len(backwardKeys) != len(testKeys) {
-		t.Errorf("Expected %d keys in backward iteration, got %d: %v", len(testKeys), len(backwardKeys), backwardKeys)
-	}
-
-	// Verify backward order (should be reverse of forward)
-	for i, expectedKey := range testKeys {
-		reverseIdx := len(testKeys) - 1 - i
-		if reverseIdx >= len(backwardKeys) || backwardKeys[reverseIdx] != expectedKey {
-			t.Errorf("Backward iteration: expected key %s at reverse position %d, got %v", expectedKey, reverseIdx, backwardKeys)
-		}
-	}
-}
-
-func TestMergeIterator_MultiSourceIteration(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_multisource_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -1303,9 +235,9 @@ func TestMergeIterator_MultiSourceIteration(t *testing.T) {
 	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
-		SyncOption:      SyncNone,
+		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 1024, // Small buffer to force flushes
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -1316,257 +248,741 @@ func TestMergeIterator_MultiSourceIteration(t *testing.T) {
 		_ = db.Close()
 	}(db)
 
-	// Insert data that will become SSTable
-	txn1 := db.Begin()
-	for i := 0; i < 10; i++ {
-		key := fmt.Sprintf("sst_key_%02d", i)
-		value := fmt.Sprintf("sst_value_%02d", i)
-		err := txn1.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put SSTable key %s: %v", key, err)
+	// Insert test data with predictable ordering
+	testKeys := []string{"a", "c", "e", "g", "i", "k", "m", "o", "q", "s"}
+	testValues := []string{"val_a", "val_c", "val_e", "val_g", "val_i", "val_k", "val_m", "val_o", "val_q", "val_s"}
+
+	err = db.Update(func(txn *Txn) error {
+		for i, key := range testKeys {
+			if err := txn.Put([]byte(key), []byte(testValues[i])); err != nil {
+				return err
+			}
 		}
-	}
-	err = txn1.Commit()
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("Failed to commit SSTable transaction: %v", err)
+		t.Fatalf("Failed to insert test data: %v", err)
+	}
+
+	t.Run("Ascending Iterator", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create ascending iterator: %v", err)
+		}
+
+		var ascendingResults []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			log.Printf("Ascending - key: %s, value: %s", string(key), string(val))
+			ascendingResults = append(ascendingResults, string(key))
+		}
+
+		// Verify ascending order
+		expectedAscending := make([]string, len(testKeys))
+		copy(expectedAscending, testKeys)
+		sort.Strings(expectedAscending)
+
+		if len(ascendingResults) != len(expectedAscending) {
+			t.Errorf("Expected %d keys, got %d", len(expectedAscending), len(ascendingResults))
+		}
+
+		for i, expected := range expectedAscending {
+			if i >= len(ascendingResults) || ascendingResults[i] != expected {
+				t.Errorf("At index %d: expected %s, got %s", i, expected,
+					func() string {
+						if i < len(ascendingResults) {
+							return ascendingResults[i]
+						}
+						return "nil"
+					}())
+			}
+		}
+
+		t.Logf("Ascending iteration passed - got keys in order: %v", ascendingResults)
+	})
+
+	t.Run("Descending Iterator", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(false)
+		if err != nil {
+			t.Fatalf("Failed to create descending iterator: %v", err)
+		}
+
+		var descendingResults []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			log.Printf("Descending - key: %s, value: %s", string(key), string(val))
+			descendingResults = append(descendingResults, string(key))
+		}
+
+		// Verify descending order
+		expectedDescending := make([]string, len(testKeys))
+		copy(expectedDescending, testKeys)
+		sort.Sort(sort.Reverse(sort.StringSlice(expectedDescending)))
+
+		if len(descendingResults) != len(expectedDescending) {
+			t.Errorf("Expected %d keys, got %d", len(expectedDescending), len(descendingResults))
+		}
+
+		for i, expected := range expectedDescending {
+			if i >= len(descendingResults) || descendingResults[i] != expected {
+				t.Errorf("At index %d: expected %s, got %s", i, expected,
+					func() string {
+						if i < len(descendingResults) {
+							return descendingResults[i]
+						}
+						return "nil"
+					}())
+			}
+		}
+
+		t.Logf("Descending iteration passed - got keys in order: %v", descendingResults)
+	})
+
+	t.Run("Bidirectional Navigation", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		// Start with ascending iterator
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		// Move forward a few steps
+		var forwardKeys []string
+		for i := 0; i < 3; i++ {
+			key, _, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			forwardKeys = append(forwardKeys, string(key))
+		}
+
+		log.Printf("Forward keys: %v", forwardKeys)
+
+		// Now go backward
+		var backwardKeys []string
+		for i := 0; i < 2; i++ {
+			key, _, _, ok := iter.Prev()
+			if !ok {
+				break
+			}
+			backwardKeys = append(backwardKeys, string(key))
+		}
+
+		log.Printf("Backward keys: %v", backwardKeys)
+
+		// Verify we can go both directions
+		if len(forwardKeys) == 0 {
+			t.Error("Failed to move forward")
+		}
+		if len(backwardKeys) == 0 {
+			t.Error("Failed to move backward")
+		}
+
+		t.Logf("Bidirectional navigation passed - forward: %v, backward: %v", forwardKeys, backwardKeys)
+	})
+
+	t.Run("Direction Change Consistency", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		// Create ascending iterator
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		// Get first key going forward
+		key1, _, _, ok1 := iter.Next()
+		if !ok1 {
+			t.Fatal("Failed to get first key")
+		}
+
+		// Change direction and get first key going backward
+		key2, _, _, ok2 := iter.Prev()
+		if !ok2 {
+			t.Fatal("Failed to get key going backward")
+		}
+
+		// Change direction again and get key going forward
+		key3, _, _, ok3 := iter.Next()
+		if !ok3 {
+			t.Fatal("Failed to get key going forward again")
+		}
+
+		log.Printf("Direction change test - key1: %s, key2: %s, key3: %s",
+			string(key1), string(key2), string(key3))
+
+		// The iterator should handle direction changes gracefully
+		// We don't enforce specific behavior here, just that it doesn't crash
+		t.Logf("Direction change consistency passed - iterator handled direction changes")
+	})
+}
+
+func TestMergeIterator_BidirectionalWithMVCC(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db_merge_iterator_bidirectional_mvcc_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	// Create a log channel
+	logChan := make(chan string, 100)
+	defer func() {
+		// Drain the log channel
+		for len(logChan) > 0 {
+			<-logChan
+		}
+	}()
+
+	// Create a test DB
+	opts := &Options{
+		Directory:       dir,
+		SyncOption:      SyncFull,
+		LogChannel:      logChan,
+		WriteBufferSize: 2 * 1024, // Small buffer to force flushing
+	}
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func(db *DB) {
+		_ = db.Close()
+	}(db)
+
+	// Insert initial data
+	err = db.Update(func(txn *Txn) error {
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%02d", i)
+			value := fmt.Sprintf("value%02d_v1", i)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to insert initial data: %v", err)
+	}
+
+	// Wait a bit and update some keys
+	time.Sleep(1 * time.Millisecond)
+	err = db.Update(func(txn *Txn) error {
+		for i := 0; i < 5; i++ {
+			key := fmt.Sprintf("key%02d", i*2) // Update even keys
+			value := fmt.Sprintf("value%02d_v2", i*2)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to update data: %v", err)
+	}
+
+	t.Run("MVCC with Ascending", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		results := make(map[string]string)
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			results[string(key)] = string(val)
+		}
+
+		// Verify we get the most recent versions
+		for i := 0; i < 10; i++ {
+			keyStr := fmt.Sprintf("key%02d", i)
+			var expectedValue string
+			if i%2 == 0 && i < 10 {
+				// Even keys were updated
+				expectedValue = fmt.Sprintf("value%02d_v2", i)
+			} else {
+				// Odd keys have original values
+				expectedValue = fmt.Sprintf("value%02d_v1", i)
+			}
+
+			if results[keyStr] != expectedValue {
+				t.Errorf("For key %s: expected %s, got %s", keyStr, expectedValue, results[keyStr])
+			}
+		}
+
+		t.Logf("MVCC ascending test passed - %d keys with correct versions", len(results))
+	})
+
+	t.Run("MVCC with Descending", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(false)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		var keys []string
+		results := make(map[string]string)
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			keyStr := string(key)
+			keys = append(keys, keyStr)
+			results[keyStr] = string(val)
+		}
+
+		// Verify descending order
+		for i := 1; i < len(keys); i++ {
+			if keys[i-1] < keys[i] {
+				t.Errorf("Keys not in descending order: %s should come after %s", keys[i-1], keys[i])
+			}
+		}
+
+		// Verify we get the most recent versions
+		for i := 0; i < 10; i++ {
+			keyStr := fmt.Sprintf("key%02d", i)
+			var expectedValue string
+			if i%2 == 0 && i < 10 {
+				expectedValue = fmt.Sprintf("value%02d_v2", i)
+			} else {
+				expectedValue = fmt.Sprintf("value%02d_v1", i)
+			}
+
+			if results[keyStr] != expectedValue {
+				t.Errorf("For key %s: expected %s, got %s", keyStr, expectedValue, results[keyStr])
+			}
+		}
+
+		t.Logf("MVCC descending test passed - %d keys in descending order with correct versions", len(results))
+	})
+}
+
+func TestMergeIterator_EdgeCases(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db_merge_iterator_edge_cases_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	// Create a log channel
+	logChan := make(chan string, 100)
+	defer func() {
+		// Drain the log channel
+		for len(logChan) > 0 {
+			<-logChan
+		}
+	}()
+
+	// Create a test DB
+	opts := &Options{
+		Directory:       dir,
+		SyncOption:      SyncFull,
+		LogChannel:      logChan,
+		WriteBufferSize: 1024,
+	}
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func(db *DB) {
+		_ = db.Close()
+	}(db)
+
+	t.Run("Empty Iterator", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		// Should not have any items
+		_, _, _, ok := iter.Next()
+		if ok {
+			t.Error("Expected empty iterator, but got items")
+		}
+
+		_, _, _, ok = iter.Prev()
+		if ok {
+			t.Error("Expected empty iterator for Prev(), but got items")
+		}
+
+		t.Log("Empty iterator test passed")
+	})
+
+	t.Run("Single Item", func(t *testing.T) {
+		// Insert one item
+		err = db.Update(func(txn *Txn) error {
+			return txn.Put([]byte("single"), []byte("item"))
+		})
+		if err != nil {
+			t.Fatalf("Failed to insert single item: %v", err)
+		}
+
+		txn := db.Begin()
+		defer txn.remove()
+
+		// Test ascending
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		key, val, _, ok := iter.Next()
+		if !ok || string(key) != "single" || string(val) != "item" {
+			t.Errorf("Expected single/item, got %s/%s (ok=%v)", string(key), string(val), ok)
+		}
+
+		// Should be no more items
+		_, _, _, ok = iter.Next()
+		if ok {
+			t.Error("Expected no more items after single item")
+		}
+
+		// Test descending
+		iter2, err := txn.NewIterator(false)
+		if err != nil {
+			t.Fatalf("Failed to create descending iterator: %v", err)
+		}
+
+		key, val, _, ok = iter2.Next()
+		if !ok || string(key) != "single" || string(val) != "item" {
+			t.Errorf("Expected single/item in descending, got %s/%s (ok=%v)", string(key), string(val), ok)
+		}
+
+		t.Log("Single item test passed")
+	})
+
+	t.Run("HasNext/HasPrev", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		// Should have items
+		if !iter.HasNext() {
+			t.Error("Expected HasNext() to return true")
+		}
+
+		// Consume all items
+		count := 0
+		for iter.HasNext() {
+			_, _, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			count++
+		}
+
+		// Should not have more items
+		if iter.HasNext() {
+			t.Error("Expected HasNext() to return false after consuming all items")
+		}
+
+		t.Logf("HasNext/HasPrev test passed - processed %d items", count)
+	})
+}
+
+func TestMergeIterator_BidirectionalMultipleSources(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db_merge_iterator_bidirectional_multisource_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	// Create a log channel
+	logChan := make(chan string, 100)
+	defer func() {
+		// Drain the log channel
+		for len(logChan) > 0 {
+			<-logChan
+		}
+	}()
+
+	// Create a test DB
+	opts := &Options{
+		Directory:       dir,
+		SyncOption:      SyncFull,
+		LogChannel:      logChan,
+		WriteBufferSize: 4 * 1024,
+	}
+
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Failed to open database: %v", err)
+	}
+	defer func(db *DB) {
+		_ = db.Close()
+	}(db)
+
+	// Insert initial batch of data (will go to SSTable)
+	err = db.Update(func(txn *Txn) error {
+		for i := 0; i < 10; i++ {
+			key := fmt.Sprintf("key%02d", i)
+			value := fmt.Sprintf("value%02d_v1", i)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to insert initial data: %v", err)
 	}
 
 	// Force flush to create SSTable
 	err = db.ForceFlush()
 	if err != nil {
-		t.Fatalf("Failed to force flush to create SSTable: %v", err)
-	}
-
-	// Insert data that will become immutable memtable
-	txn2 := db.Begin()
-	for i := 10; i < 20; i++ {
-		key := fmt.Sprintf("imm_key_%02d", i)
-		value := fmt.Sprintf("imm_value_%02d", i)
-		err := txn2.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put immutable key %s: %v", key, err)
-		}
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit immutable transaction: %v", err)
-	}
-
-	// Force flush to create immutable memtable
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to force flush to create immutable memtable: %v", err)
-	}
-
-	// Insert data that will stay in active memtable
-	txn3 := db.Begin()
-	for i := 20; i < 30; i++ {
-		key := fmt.Sprintf("mem_key_%02d", i)
-		value := fmt.Sprintf("mem_value_%02d", i)
-		err := txn3.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put memtable key %s: %v", key, err)
-		}
-	}
-	err = txn3.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit memtable transaction: %v", err)
-	}
-
-	// Test iteration across all sources
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, nil)
-
-	var allKeys []string
-	var sourceCount = make(map[string]int)
-
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		keyStr := string(key)
-		allKeys = append(allKeys, keyStr)
-
-		// Count keys by source
-		if bytes.HasPrefix(key, []byte("sst_")) {
-			sourceCount["sstable"]++
-		} else if bytes.HasPrefix(key, []byte("imm_")) {
-			sourceCount["immutable"]++
-		} else if bytes.HasPrefix(key, []byte("mem_")) {
-			sourceCount["memtable"]++
-		}
-	}
-
-	// Verify we got keys from all sources
-	expectedTotal := 30
-	if len(allKeys) != expectedTotal {
-		t.Errorf("Expected %d total keys, got %d", expectedTotal, len(allKeys))
-	}
-
-	if sourceCount["sstable"] != 10 {
-		t.Errorf("Expected 10 SSTable keys, got %d", sourceCount["sstable"])
-	}
-	if sourceCount["immutable"] != 10 {
-		t.Errorf("Expected 10 immutable memtable keys, got %d", sourceCount["immutable"])
-	}
-	if sourceCount["memtable"] != 10 {
-		t.Errorf("Expected 10 memtable keys, got %d", sourceCount["memtable"])
-	}
-
-	// Verify keys are sorted
-	for i := 1; i < len(allKeys); i++ {
-		if allKeys[i-1] >= allKeys[i] {
-			t.Errorf("Keys not sorted: %s >= %s at positions %d, %d", allKeys[i-1], allKeys[i], i-1, i)
-		}
-	}
-
-	t.Logf("Successfully merged %d keys from %d sources: %d SSTable, %d immutable, %d memtable",
-		len(allKeys), len(sourceCount), sourceCount["sstable"], sourceCount["immutable"], sourceCount["memtable"])
-}
-
-func TestMergeIterator_OverlappingKeysMultiSource(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_overlap_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
-
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
-
-	// Create a test DB
-	opts := &Options{
-		Directory:       dir,
-		SyncOption:      SyncNone,
-		LogChannel:      logChan,
-		WriteBufferSize: 512, // Small buffer to force flushes
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Insert initial versions (will become SSTable)
-	txn1 := db.Begin()
-	for i := 0; i < 5; i++ {
-		key := fmt.Sprintf("key%d", i)
-		value := fmt.Sprintf("v1_%s", key)
-		err := txn1.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put initial key %s: %v", key, err)
-		}
-	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit initial transaction: %v", err)
-	}
-
-	// Force flush
-	err = db.ForceFlush()
-	if err != nil {
 		t.Fatalf("Failed to force flush: %v", err)
 	}
 
-	// Update some keys (will become immutable memtable)
-	time.Sleep(time.Millisecond) // Ensure different timestamp
-	txn2 := db.Begin()
-	for i := 0; i < 3; i++ {
-		key := fmt.Sprintf("key%d", i)
-		value := fmt.Sprintf("v2_%s", key)
-		err := txn2.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put updated key %s: %v", key, err)
+	// Insert second batch with some overlapping keys (will go to another SSTable)
+	err = db.Update(func(txn *Txn) error {
+		for i := 5; i < 15; i++ {
+			key := fmt.Sprintf("key%02d", i)
+			value := fmt.Sprintf("value%02d_v2", i)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
 		}
-	}
-	err = txn2.Commit()
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("Failed to commit update transaction: %v", err)
+		t.Fatalf("Failed to insert second batch: %v", err)
 	}
 
-	// Force flush
+	// Force another flush to create second SSTable
 	err = db.ForceFlush()
 	if err != nil {
-		t.Fatalf("Failed to force flush: %v", err)
+		t.Fatalf("Failed to force second flush: %v", err)
 	}
 
-	// Update some keys again (will stay in memtable)
-	time.Sleep(time.Millisecond) // Ensure different timestamp
-	txn3 := db.Begin()
-	for i := 0; i < 2; i++ {
-		key := fmt.Sprintf("key%d", i)
-		value := fmt.Sprintf("v3_%s", key)
-		err := txn3.Put([]byte(key), []byte(value))
-		if err != nil {
-			t.Fatalf("Failed to put final key %s: %v", key, err)
+	// Insert third batch with some new and updated keys (will stay in memtable)
+	err = db.Update(func(txn *Txn) error {
+		for i := 10; i < 20; i++ {
+			key := fmt.Sprintf("key%02d", i)
+			value := fmt.Sprintf("value%02d_v3", i)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
 		}
-	}
-	err = txn3.Commit()
+		// Add some keys that update earlier ones
+		for i := 0; i < 5; i++ {
+			key := fmt.Sprintf("key%02d", i)
+			value := fmt.Sprintf("value%02d_v3", i)
+			if err := txn.Put([]byte(key), []byte(value)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("Failed to commit final transaction: %v", err)
+		t.Fatalf("Failed to insert third batch: %v", err)
 	}
 
-	// Test iteration, should see latest versions
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, nil)
+	// Print stats to verify we have multiple sources
+	log.Println("Database stats after multiple writes:")
+	log.Println(db.Stats())
 
-	expectedValues := map[string]string{
-		"key0": "v3_key0", // Latest version from memtable
-		"key1": "v3_key1", // Latest version from memtable
-		"key2": "v2_key2", // Latest version from immutable memtable
-		"key3": "v1_key3", // Original version from SSTable
-		"key4": "v1_key4", // Original version from SSTable
-	}
+	t.Run("Ascending with Multiple Sources", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
 
-	var foundKeys []string
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create ascending iterator: %v", err)
 		}
 
-		keyStr := string(key)
-		valueStr := string(value)
-		foundKeys = append(foundKeys, keyStr)
-
-		expectedValue, exists := expectedValues[keyStr]
-		if !exists {
-			t.Errorf("Unexpected key found: %s", keyStr)
-			continue
+		results := make(map[string]string)
+		var keys []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			keyStr := string(key)
+			keys = append(keys, keyStr)
+			results[keyStr] = string(val)
+			log.Printf("Ascending multi-source - key: %s, value: %s", keyStr, string(val))
 		}
 
-		if valueStr != expectedValue {
-			t.Errorf("For key %s, expected value %s, got %s", keyStr, expectedValue, valueStr)
+		// Verify ascending order
+		for i := 1; i < len(keys); i++ {
+			if keys[i-1] >= keys[i] {
+				t.Errorf("Keys not in ascending order: %s should come before %s", keys[i-1], keys[i])
+			}
 		}
 
-		t.Logf("Key: %s, Value: %s", keyStr, valueStr)
-	}
+		// Verify we get the most recent versions (MVCC validation)
+		expectedResults := make(map[string]string)
+		// Keys 0-4: v3 (updated in third batch)
+		for i := 0; i < 5; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
+		// Keys 5-9: v2 (updated in second batch)
+		for i := 5; i < 10; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v2", i)
+		}
+		// Keys 10-14: v3 (from third batch, overwrites v2)
+		for i := 10; i < 15; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
+		// Keys 15-19: v3 (only in third batch)
+		for i := 15; i < 20; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
 
-	if len(foundKeys) != len(expectedValues) {
-		t.Errorf("Expected %d unique keys, got %d: %v", len(expectedValues), len(foundKeys), foundKeys)
-	}
+		for expectedKey, expectedValue := range expectedResults {
+			if results[expectedKey] != expectedValue {
+				t.Errorf("For key %s: expected %s, got %s", expectedKey, expectedValue, results[expectedKey])
+			}
+		}
+
+		t.Logf("Ascending multi-source test passed - %d keys in correct order with MVCC", len(results))
+	})
+
+	t.Run("Descending with Multiple Sources", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(false)
+		if err != nil {
+			t.Fatalf("Failed to create descending iterator: %v", err)
+		}
+
+		results := make(map[string]string)
+		var keys []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			keyStr := string(key)
+			keys = append(keys, keyStr)
+			results[keyStr] = string(val)
+			log.Printf("Descending multi-source - key: %s, value: %s", keyStr, string(val))
+		}
+
+		// Verify descending order
+		for i := 1; i < len(keys); i++ {
+			if keys[i-1] <= keys[i] {
+				t.Errorf("Keys not in descending order: %s should come after %s", keys[i-1], keys[i])
+			}
+		}
+
+		// Same MVCC validation as ascending test
+		expectedResults := make(map[string]string)
+		for i := 0; i < 5; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
+		for i := 5; i < 10; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v2", i)
+		}
+		for i := 10; i < 15; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
+		for i := 15; i < 20; i++ {
+			expectedResults[fmt.Sprintf("key%02d", i)] = fmt.Sprintf("value%02d_v3", i)
+		}
+
+		for expectedKey, expectedValue := range expectedResults {
+			if results[expectedKey] != expectedValue {
+				t.Errorf("For key %s: expected %s, got %s", expectedKey, expectedValue, results[expectedKey])
+			}
+		}
+
+		t.Logf("Descending multi-source test passed - %d keys in correct order with MVCC", len(results))
+	})
+
+	t.Run("Bidirectional Navigation with Multiple Sources", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		// Start with ascending iterator
+		iter, err := txn.NewIterator(true)
+		if err != nil {
+			t.Fatalf("Failed to create iterator: %v", err)
+		}
+
+		// Move forward several steps
+		var forwardKeys []string
+		for i := 0; i < 5; i++ {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			forwardKeys = append(forwardKeys, string(key))
+			log.Printf("Forward multi-source - key: %s, value: %s", string(key), string(val))
+		}
+
+		// Change direction and go backward
+		var backwardKeys []string
+		for i := 0; i < 3; i++ {
+			key, val, _, ok := iter.Prev()
+			if !ok {
+				break
+			}
+			backwardKeys = append(backwardKeys, string(key))
+			log.Printf("Backward multi-source - key: %s, value: %s", string(key), string(val))
+		}
+
+		// Change direction again and go forward
+		var forwardAgainKeys []string
+		for i := 0; i < 2; i++ {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			forwardAgainKeys = append(forwardAgainKeys, string(key))
+			log.Printf("Forward again multi-source - key: %s, value: %s", string(key), string(val))
+		}
+
+		// Verify we can navigate in both directions
+		if len(forwardKeys) == 0 {
+			t.Error("Failed to move forward with multiple sources")
+		}
+		if len(backwardKeys) == 0 {
+			t.Error("Failed to move backward with multiple sources")
+		}
+		if len(forwardAgainKeys) == 0 {
+			t.Error("Failed to move forward again with multiple sources")
+		}
+
+		t.Logf("Bidirectional multi-source navigation passed - forward: %v, backward: %v, forward again: %v",
+			forwardKeys, backwardKeys, forwardAgainKeys)
+	})
 }
 
-func TestMergeIterator_PrefixFilteringMultiSource(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_prefix_multisource_test")
+func TestMergeIterator_BidirectionalStressTest(t *testing.T) {
+	dir, err := os.MkdirTemp("", "db_merge_iterator_bidirectional_stress_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -1580,9 +996,9 @@ func TestMergeIterator_PrefixFilteringMultiSource(t *testing.T) {
 	// Create a test DB
 	opts := &Options{
 		Directory:       dir,
-		SyncOption:      SyncNone,
+		SyncOption:      SyncFull,
 		LogChannel:      logChan,
-		WriteBufferSize: 512, // Small buffer to force flushes
+		WriteBufferSize: 4 * 1024,
 	}
 
 	db, err := Open(opts)
@@ -1593,258 +1009,158 @@ func TestMergeIterator_PrefixFilteringMultiSource(t *testing.T) {
 		_ = db.Close()
 	}(db)
 
-	// Insert user data that will become SSTable
-	txn1 := db.Begin()
-	sstableUsers := []string{"user:alice", "user:bob", "config:db_host", "config:db_port"}
-	for _, key := range sstableUsers {
-		err := txn1.Put([]byte(key), []byte("sstable_"+key))
+	// Create multiple batches with overlapping keys to stress test merging
+	numBatches := 5
+	keysPerBatch := 10
+
+	for batch := 0; batch < numBatches; batch++ {
+		err = db.Update(func(txn *Txn) error {
+			for i := 0; i < keysPerBatch; i++ {
+				// Create overlapping keys across batches
+				keyIndex := (batch*keysPerBatch/2 + i) % (keysPerBatch * 2)
+				key := fmt.Sprintf("stress_key_%03d", keyIndex)
+				value := fmt.Sprintf("stress_value_%03d_batch_%d", keyIndex, batch)
+				if err := txn.Put([]byte(key), []byte(value)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 		if err != nil {
-			t.Fatalf("Failed to put SSTable key %s: %v", key, err)
+			t.Fatalf("Failed to insert batch %d: %v", batch, err)
+		}
+
+		// Force flush after each batch to create separate SSTables
+		if batch < numBatches-1 { // Don't flush the last batch, keep it in memtable
+			err = db.ForceFlush()
+			if err != nil {
+				t.Fatalf("Failed to force flush after batch %d: %v", batch, err)
+			}
 		}
 	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit SSTable transaction: %v", err)
-	}
 
-	// Force flush to create SSTable
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to force flush to create SSTable: %v", err)
-	}
+	// Print final stats
+	log.Println("Stress test database stats:")
+	log.Println(db.Stats())
 
-	// Insert more user data that will become immutable memtable
-	txn2 := db.Begin()
-	immutableUsers := []string{"user:charlie", "user:david", "session:abc", "session:def"}
-	for _, key := range immutableUsers {
-		err := txn2.Put([]byte(key), []byte("immutable_"+key))
+	t.Run("Stress Test Ascending", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(true)
 		if err != nil {
-			t.Fatalf("Failed to put immutable key %s: %v", key, err)
+			t.Fatalf("Failed to create iterator: %v", err)
 		}
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit immutable transaction: %v", err)
-	}
 
-	// Force flush to create immutable memtable
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to force flush to create immutable memtable: %v", err)
-	}
+		results := make(map[string]string)
+		var keys []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			keyStr := string(key)
+			keys = append(keys, keyStr)
+			results[keyStr] = string(val)
+		}
 
-	// Insert more user data that will stay in active memtable
-	txn3 := db.Begin()
-	memtableUsers := []string{"user:eve", "user:frank", "temp:file1", "temp:file2"}
-	for _, key := range memtableUsers {
-		err := txn3.Put([]byte(key), []byte("memtable_"+key))
+		// Verify ascending order
+		for i := 1; i < len(keys); i++ {
+			if keys[i-1] >= keys[i] {
+				t.Errorf("Keys not in ascending order: %s should come before %s", keys[i-1], keys[i])
+			}
+		}
+
+		// Verify we have the expected number of unique keys
+		expectedUniqueKeys := keysPerBatch * 2 // Due to overlapping pattern
+		if len(results) != expectedUniqueKeys {
+			t.Errorf("Expected %d unique keys, got %d", expectedUniqueKeys, len(results))
+		}
+
+		t.Logf("Stress test ascending passed - %d keys in correct order", len(results))
+	})
+
+	t.Run("Stress Test Descending", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
+
+		iter, err := txn.NewIterator(false)
 		if err != nil {
-			t.Fatalf("Failed to put memtable key %s: %v", key, err)
-		}
-	}
-	err = txn3.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit memtable transaction: %v", err)
-	}
-
-	// Test prefix filtering for "user:" across all sources
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator(nil, []byte("user:"))
-
-	var userKeys []string
-	var sourceCount = make(map[string]int)
-
-	for {
-		key, value, _, ok := iter.Next()
-		if !ok {
-			break
+			t.Fatalf("Failed to create iterator: %v", err)
 		}
 
-		keyStr := string(key)
-		valueStr := string(value)
-		userKeys = append(userKeys, keyStr)
-
-		// Verify prefix
-		if !bytes.HasPrefix([]byte(keyStr), []byte("user:")) {
-			t.Errorf("Key %s does not have user: prefix", keyStr)
+		results := make(map[string]string)
+		var keys []string
+		for {
+			key, val, _, ok := iter.Next()
+			if !ok {
+				break
+			}
+			keyStr := string(key)
+			keys = append(keys, keyStr)
+			results[keyStr] = string(val)
 		}
 
-		// Count by source
-		if bytes.HasPrefix([]byte(valueStr), []byte("sstable_")) {
-			sourceCount["sstable"]++
-		} else if bytes.HasPrefix([]byte(valueStr), []byte("immutable_")) {
-			sourceCount["immutable"]++
-		} else if bytes.HasPrefix([]byte(valueStr), []byte("memtable_")) {
-			sourceCount["memtable"]++
+		// Verify descending order
+		for i := 1; i < len(keys); i++ {
+			if keys[i-1] <= keys[i] {
+				t.Errorf("Keys not in descending order: %s should come after %s", keys[i-1], keys[i])
+			}
 		}
 
-		t.Logf("User key: %s, Value: %s", keyStr, valueStr)
-	}
-
-	// Verify we got user keys from all sources
-	expectedUserKeys := []string{"user:alice", "user:bob", "user:charlie", "user:david", "user:eve", "user:frank"}
-	if len(userKeys) != len(expectedUserKeys) {
-		t.Errorf("Expected %d user keys, got %d: %v", len(expectedUserKeys), len(userKeys), userKeys)
-	}
-
-	// Verify distribution across sources
-	if sourceCount["sstable"] != 2 {
-		t.Errorf("Expected 2 user keys from SSTable, got %d", sourceCount["sstable"])
-	}
-	if sourceCount["immutable"] != 2 {
-		t.Errorf("Expected 2 user keys from immutable memtable, got %d", sourceCount["immutable"])
-	}
-	if sourceCount["memtable"] != 2 {
-		t.Errorf("Expected 2 user keys from memtable, got %d", sourceCount["memtable"])
-	}
-
-	// Verify keys are sorted
-	for i := 1; i < len(userKeys); i++ {
-		if userKeys[i-1] >= userKeys[i] {
-			t.Errorf("User keys not sorted: %s >= %s", userKeys[i-1], userKeys[i])
+		// Verify we have the expected number of unique keys
+		expectedUniqueKeys := keysPerBatch * 2
+		if len(results) != expectedUniqueKeys {
+			t.Errorf("Expected %d unique keys, got %d", expectedUniqueKeys, len(results))
 		}
-	}
-}
 
-func TestMergeIterator_StartKeyMultiSource(t *testing.T) {
-	dir, err := os.MkdirTemp("", "db_merge_iterator_startkey_multisource_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
+		t.Logf("Stress test descending passed - %d keys in correct order", len(results))
+	})
 
-	// Create a log channel
-	logChan := make(chan string, 100)
-	defer func() {
-		// Drain the log channel
-		for len(logChan) > 0 {
-			<-logChan
-		}
-	}()
+	t.Run("Stress Test Direction Changes", func(t *testing.T) {
+		txn := db.Begin()
+		defer txn.remove()
 
-	// Create a test DB
-	opts := &Options{
-		Directory:       dir,
-		SyncOption:      SyncNone,
-		LogChannel:      logChan,
-		WriteBufferSize: 512,
-	}
-
-	db, err := Open(opts)
-	if err != nil {
-		t.Fatalf("Failed to open database: %v", err)
-	}
-	defer func(db *DB) {
-		_ = db.Close()
-	}(db)
-
-	// Distribute keys across multiple sources with known ordering
-	allKeys := []string{
-		"key01", "key03", "key05", "key07", "key09", // Will go to SSTable
-		"key11", "key13", "key15", "key17", "key19", // Will go to immutable
-		"key21", "key23", "key25", "key27", "key29", // Will stay in memtable
-	}
-
-	// Insert first batch (SSTable)
-	txn1 := db.Begin()
-	for i := 0; i < 5; i++ {
-		key := allKeys[i]
-		err := txn1.Put([]byte(key), []byte("sstable_"+key))
+		iter, err := txn.NewIterator(true)
 		if err != nil {
-			t.Fatalf("Failed to put SSTable key %s: %v", key, err)
-		}
-	}
-	err = txn1.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit SSTable transaction: %v", err)
-	}
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to flush SSTable: %v", err)
-	}
-
-	// Insert second batch (immutable)
-	txn2 := db.Begin()
-	for i := 5; i < 10; i++ {
-		key := allKeys[i]
-		err := txn2.Put([]byte(key), []byte("immutable_"+key))
-		if err != nil {
-			t.Fatalf("Failed to put immutable key %s: %v", key, err)
-		}
-	}
-	err = txn2.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit immutable transaction: %v", err)
-	}
-	err = db.ForceFlush()
-	if err != nil {
-		t.Fatalf("Failed to flush immutable: %v", err)
-	}
-
-	// Insert third batch (memtable)
-	txn3 := db.Begin()
-	for i := 10; i < 15; i++ {
-		key := allKeys[i]
-		err := txn3.Put([]byte(key), []byte("memtable_"+key))
-		if err != nil {
-			t.Fatalf("Failed to put memtable key %s: %v", key, err)
-		}
-	}
-	err = txn3.Commit()
-	if err != nil {
-		t.Fatalf("Failed to commit memtable transaction: %v", err)
-	}
-
-	// Test iteration starting from "key15" (should get keys >= key15)
-	txnRead := db.Begin()
-	iter := txnRead.NewIterator([]byte("key15"), nil)
-
-	var foundKeys []string
-	for {
-		key, _, _, ok := iter.Next()
-		if !ok {
-			break
-		}
-		foundKeys = append(foundKeys, string(key))
-	}
-
-	// Should get= key15, key17, key19, key21, key23, key25, key27, key29
-	expectedKeys := []string{"key15", "key17", "key19", "key21", "key23", "key25", "key27", "key29"}
-	if len(foundKeys) != len(expectedKeys) {
-		t.Errorf("Expected %d keys starting from key15, got %d: %v", len(expectedKeys), len(foundKeys), foundKeys)
-	}
-
-	for i, expectedKey := range expectedKeys {
-		if i >= len(foundKeys) || foundKeys[i] != expectedKey {
-			t.Errorf("Expected key %s at position %d, got %v", expectedKey, i, foundKeys)
-		}
-	}
-
-	// Verify we got keys from multiple sources
-	var sourceCount = make(map[string]int)
-	txnRead2 := db.Begin()
-	iter2 := txnRead2.NewIterator([]byte("key15"), nil)
-
-	for {
-		key, value, _, ok := iter2.Next()
-		if !ok {
-			break
+			t.Fatalf("Failed to create iterator: %v", err)
 		}
 
-		valueStr := string(value)
-		if bytes.HasPrefix([]byte(valueStr), []byte("sstable_")) {
-			sourceCount["sstable"]++
-		} else if bytes.HasPrefix([]byte(valueStr), []byte("immutable_")) {
-			sourceCount["immutable"]++
-		} else if bytes.HasPrefix([]byte(valueStr), []byte("memtable_")) {
-			sourceCount["memtable"]++
+		// Perform multiple direction changes
+		directions := []string{"forward", "backward", "forward", "backward", "forward"}
+		allKeys := make([][]string, len(directions))
+
+		for dirIndex, direction := range directions {
+			var keys []string
+			steps := 3 // Take 3 steps in each direction
+
+			for i := 0; i < steps; i++ {
+				var key []byte
+				var ok bool
+
+				if direction == "forward" {
+					key, _, _, ok = iter.Next()
+				} else {
+					key, _, _, ok = iter.Prev()
+				}
+
+				if !ok {
+					break
+				}
+				keys = append(keys, string(key))
+			}
+
+			allKeys[dirIndex] = keys
+			log.Printf("Stress direction %s: %v", direction, keys)
 		}
 
-		t.Logf("Start key iteration - Key: %s, Value: %s", string(key), valueStr)
-	}
+		// Verify each direction change worked
+		for i, keys := range allKeys {
+			if len(keys) == 0 && i < 2 { // First two directions should have data
+				t.Errorf("Direction %s (index %d) returned no keys", directions[i], i)
+			}
+		}
 
-	t.Logf("Source distribution: SSTable=%d, Immutable=%d, Memtable=%d",
-		sourceCount["sstable"], sourceCount["immutable"], sourceCount["memtable"])
+		t.Logf("Stress test direction changes passed - handled %d direction changes", len(directions))
+	})
 }

--- a/readme.md
+++ b/readme.md
@@ -7,29 +7,9 @@
 
 Wildcat is a high-performance embedded key-value database (or storage engine) written in Go. It incorporates modern database design principles including LSM (Log-Structured Merge) tree architecture, MVCC (Multi-Version Concurrency Control), and lock-free data structures for its critical paths, along with automatic background operations to deliver excellent read/write performance with strong consistency guarantees.
 
-## Table of Contents
-- [Features](#features)
-- [Basic Usage](#basic-usage)
-- [Version and Compatibility](#version-and-compatibility)
-- [Advanced Configuration](#advanced-configuration)
-- [Transaction Management](#manual-transaction-management)
-- [Iteration](#iterating-keys)
-- [Architecture Overview](#architecture-overview)
-- [Log Channel](#log-channel)
-- [MVCC Model](#mvcc-model)
-- [WAL and Durability](#wal-and-durability)
-- [Concurrency Model](#concurrency-model)
-- [Recoverability](#recoverability-guarantee-order)
-- [Isolation Levels](#isolation-levels)
-- [SSTable Format](#sstable-format)
-- [SSTable Metadata](#sstable-metadata)
-- [Compaction](#sstables-and-compaction)
-- [Motivation](#motivation)
-- [Contributing](#contributing)
-
 ## Features
 - LSM (Log-Structured Merge) tree architecture optimized for high write throughput
-- Minimal to no blocking concurrency for readers and writers
+- Lock-free MVCC ensures non-blocking reads and writes
 - WAL logging captures full transaction state for recovery and rehydration
 - Version-aware skip list for fast in-memory MVCC access
 - Atomic write path, safe for multithreaded use
@@ -37,16 +17,54 @@ Wildcat is a high-performance embedded key-value database (or storage engine) wr
 - Durable and concurrent block storage, leveraging direct, offset-based file I/O (using `pread`/`pwrite`) for optimal performance and control
 - Atomic LRU for active block manager handles
 - Memtable lifecycle management and snapshot durability
+- SSTables are immutable BTree's
 - Configurable Sync options such as `None`, `Partial (with background interval)`, `Full`
 - Snapshot-isolated MVCC with read timestamps
 - Crash recovery restores all in-flight and committed transactions
 - Automatic multi-threaded background compaction
 - Full ACID transaction support
-- Bidirectional iteration with MVCC-consistent visibility
+- Range, prefix, and full iteration support with bidirectional traversal
 - Sustains 100K+ txns/sec writes, and hundreds of thousands of reads/sec
 - Optional Bloom filter per SSTable for fast key lookups
 - Key value separation optimization (`.klog` for keys, `.vlog` for values, klog entries point to vlog entries)
 - Tombstone-aware compaction with retention based on active transaction windows
+- Transaction recovery with incomplete transactions are preserved and accessible after crashes
+
+## Table of Contents
+- [Version and Compatibility](#version-and-compatibility)
+- [Basic Usage](#basic-usage)
+  - [Opening a Wildcat DB instance](#opening-a-wildcat-db-instance)
+  - [Advanced Configuration](#advanced-configuration)
+  - [Simple Key-Value Operations](#simple-key-value-operations)
+  - [Manual Transaction Management](#manual-transaction-management)
+  - [Iterating Keys](#iterating-keys)
+    - [Full Iterator (bidirectional)](#full-iterator-bidirectional)
+    - [Range Iterator (bidirectional)](#range-iterator-bidirectional)
+    - [Prefix Iterator (bidirectional)](#prefix-iterator-bidirectional)
+  - [Read-Only Transactions with View](#read-only-transactions-with-view)
+  - [Batch Operations](#batch-operations)
+  - [Transaction Recovery](#transaction-recovery)
+  - [Log Channel](#log-channel)
+  - [Database Statistics](#database-statistics)
+  - [Force Flushing](#force-flushing)
+- [Overview](#overview)
+    - [MVCC Model](#mvcc-model)
+    - [WAL and Durability](#wal-and-durability)
+    - [Memtable Lifecycle](#memtable-lifecycle)
+    - [SSTables and Compaction](#sstables-and-compaction)
+    - [SSTable Metadata](#sstable-metadata)
+    - [SSTable Format](#sstable-format)
+    - [Compaction Policy / Strategy](#compaction-policy--strategy)
+    - [Concurrency Model](#concurrency-model)
+    - [Isolation Levels](#isolation-levels)
+    - [Recoverability Guarantee Order](#recoverability-guarantee-order)
+    - [Block Manager](#block-manager)
+    - [LRU Cache](#lru-cache)
+    - [Lock-Free Queue](#lock-free-queue)
+    - [BTree](#btree)
+    - [SkipList](#skiplist)
+- [Motivation](#motivation)
+- [Contributing](#contributing)
 
 ## Version and Compatibility
 - Go 1.24+
@@ -54,6 +72,13 @@ Wildcat is a high-performance embedded key-value database (or storage engine) wr
 
 ## Basic Usage
 Wildcat supports opening multiple `wildcat.DB` instances in parallel, each operating independently in separate directories.
+
+### Import
+```go
+import (
+    "github.com/guycipher/wildcat"
+)
+```
 
 ### Opening a Wildcat DB instance
 The only required option is the database directory path.
@@ -76,45 +101,59 @@ defer db.Close()
 Wildcat provides several configuration options for fine-tuning.
 ```go
 opts := &wildcat.Options{
-    Directory:           "/path/to/database",     // Directory for database files
-    WriteBufferSize:     32 * 1024 * 1024,        // 32MB memtable size
-    SyncOption:          wildcat.SyncFull,        // Full sync for maximum durability
-    SyncInterval:        128 * time.Millisecond,  // Only set when using SyncPartial, can be 0 otherwise
-    LevelCount:          7,                       // Number of LSM levels
-    LevelMultiplier:     10,                      // Size multiplier between levels
-    BlockManagerLRUSize: 256,                     // Cache size for block managers
-    BlockSetSize:        8 * 1024 * 1024,         // 8MB block set size, each klog block will have BlockSetSize of entries
-    LogChannel:          make(chan string, 1000), // Channel for real time logging
-    BloomFilter:         false,                   // Enable/disable sstable bloom filters
+    Directory:                   "/path/to/database",     // Directory for database files
+    WriteBufferSize:             32 * 1024 * 1024,        // 32MB memtable size
+    SyncOption:                  wildcat.SyncFull,        // Full sync for maximum durability
+    SyncInterval:                128 * time.Millisecond,  // Only set when using SyncPartial
+    LevelCount:                  7,                       // Number of LSM levels
+    LevelMultiplier:             10,                      // Size multiplier between levels
+    BlockManagerLRUSize:         256,                     // Cache size for block managers
+    SSTableBTreeOrder:           10,                      // BTree order for SSTable klog
+    LogChannel:                  make(chan string, 1000), // Channel for real time logging
+    BloomFilter:                 false,                   // Enable/disable sstable bloom filters
+    MaxCompactionConcurrency:    4,                       // Maximum concurrent compactions
+    CompactionCooldownPeriod:    5 * time.Second,         // Cooldown between compactions
+    CompactionBatchSize:         8,                       // Max SSTables per compaction
+    CompactionSizeRatio:         1.1,                     // Level size ratio trigger
+    CompactionSizeThreshold:     8,                       // File count trigger
+    CompactionScoreSizeWeight:   0.8,                     // Weight for size-based scoring
+    CompactionScoreCountWeight:  0.2,                     // Weight for count-based scoring
+    FlusherTickerInterval:       1 * time.Millisecond,    // Flusher check interval
+    CompactorTickerInterval:     250 * time.Millisecond,  // Compactor check interval
+    BloomFilterFPR:              0.01,                    // Bloom filter false positive rate
+    WalAppendRetry:              10,                      // WAL append retry count
+    WalAppendBackoff:            128 * time.Microsecond,  // WAL append retry backoff
+    BlockManagerLRUEvictRatio:   0.20,                    // LRU eviction ratio
+    BlockManagerLRUAccesWeight:  0.8,                     // LRU access weight
 }
 ```
 
 #### Configuration Options Explained
 1. **Directory** The path where the database files will be stored
 2. **WriteBufferSize** Size threshold for memtable before flushing to disk
-3. **SyncOption** Controls durability vs performance tradeoff:
+3. **SyncOption** Controls durability vs performance tradeoff
     - **SyncNone** Fastest, but no durability guarantees
     - **SyncPartial** Balances performance and durability
     - **SyncFull** Maximum durability, slower performance
-4. **SyncInterval** Time between background sync operations
+4. **SyncInterval** Time between background sync operations (only for SyncPartial)
 5. **LevelCount** Number of levels in the LSM tree
 6. **LevelMultiplier** Size ratio between adjacent levels
 7. **BlockManagerLRUSize** Number of block managers to cache
-8. **BlockSetSize** Size of SSTable klog block sets
+8. **SSTableBTreeOrder** Size of SSTable klog block sets
 9. **LogChannel** Channel for real-time logging, useful for debugging and monitoring
-10. **BloomFilter** Enable or disable bloom filters for SSTables to speed up key lookups
+10. **BloomFilter** Enable or disable bloom filters for SSTables to speed up key lookups. Bloom filters use double hashing with FNV-1a and FNV hash functions.  Is automatically sized based on expected items and desired false positive rate.
 11. **MaxCompactionConcurrency** Maximum number of concurrent compactions
-12. **CompactionCooldownPeriod** Cooldown period for compaction
+12. **CompactionCooldownPeriod** Cooldown period between compactions to prevent thrashing
 13. **CompactionBatchSize** Max number of SSTables to compact at once
 14. **CompactionSizeRatio** Level size ratio that triggers compaction
 15. **CompactionSizeThreshold** Number of files to trigger size-tiered compaction
-16. **CompactionScoreSizeWeight** Weight for size-based score
-17. **CompactionScoreCountWeight** Weight for count-based score
-18. **FlusherTickerInterval** Interval for flusher ticker
-19. **CompactorTickerInterval** Interval for compactor ticker
-20. **BloomFilterFPR** False positive rate for Bloom filter
-21. **WalAppendRetry** Number of retries for WAL append
-22. **WalAppendBackoff** Backoff duration for WAL append
+16. **CompactionScoreSizeWeight** Weight for size-based compaction scoring
+17. **CompactionScoreCountWeight** Weight for count-based compaction scoring
+18. **FlusherTickerInterval** Interval for flusher background process
+19. **CompactorTickerInterval** Interval for compactor background process
+20. **BloomFilterFPR** False positive rate for Bloom filters
+21. **WalAppendRetry** Number of retries for WAL append operations
+22. **WalAppendBackoff** Backoff duration for WAL append retries
 23. **BlockManagerLRUEvictRatio** Ratio for LRU eviction. Determines what percentage of the cache to evict when cleanup is needed.
 24. **BlockManagerLRUAccesWeight** Weight for LRU access eviction. Balances how much to prioritize access frequency vs. age when deciding what to evict.
 
@@ -172,40 +211,120 @@ if err != nil {
 ```
 
 ### Iterating Keys
-Wildcat supports MVCC-consistent, bidirectional iteration. You iterate over keys and their values in order, no duplicates, and consistent!
+Wildcat provides comprehensive iteration capabilities with MVCC consistency.
+
+You can set ascending or descending order, and iterate over all keys, a range of keys, or keys with a specific prefix.
+
+#### Full Iterator (bidirectional)
 ```go
-txn := db.Begin()
-iter := txn.NewIterator(nil, nil)
-
-for {
-    key, val, ts, ok := iter.Next()
-    if !ok {
-        break
+err := db.View(func(txn *wildcat.Txn) error {
+    // Create ascending iterator
+    iter, err := txn.NewIterator(true)
+    if err != nil {
+        return err
     }
-    fmt.Printf("Key=%s Value=%s Timestamp=%d\n", key, val, ts)
-}
 
-for {
-    key, val, ts, ok := iter.Prev()
-    if !ok {
-        break
-    }
-    fmt.Printf("Key=%s Value=%s Timestamp=%d\n", key, val, ts)
-}
-```
-
-Or using a transaction block.
-
-```go
-db.Update(func(txn *wildcat.Txn) error {
-    iter := txn.NewIterator(nil, nil)
+    // Iterate forward
     for {
-        key, val, ts, ok := iter.Next()
+        key, value, timestamp, ok := iter.Next()
         if !ok {
             break
         }
-        fmt.Printf("Key=%s Value=%s Timestamp=%d\n", key, val, ts)
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
     }
+
+    // Change direction and iterate backward
+    err = iter.SetDirection(false)
+    if err != nil {
+        return err
+    }
+
+    for {
+        key, value, timestamp, ok := iter.Next()
+        if !ok {
+            break
+        }
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
+    }
+
+    return nil
+})
+```
+
+#### Range Iterator (bidirectional)
+```go
+err := db.View(func(txn *wildcat.Txn) error {
+    // Create range iterator
+    iter, err := txn.NewRangeIterator([]byte("start"), []byte("end"), true)
+    if err != nil {
+        return err
+    }
+
+    // Iterate forward
+    for {
+        key, value, timestamp, ok := iter.Next()
+        if !ok {
+            break
+        }
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
+    }
+
+    // Change direction and iterate backward
+    err = iter.SetDirection(false)
+    if err != nil {
+        return err
+    }
+
+    for {
+        key, value, timestamp, ok := iter.Next()
+        if !ok {
+            break
+        }
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
+    }
+
+    return nil
+})
+```
+
+#### Prefix Iterator (bidirectional)
+```go
+err := db.View(func(txn *wildcat.Txn) error {
+    // Create prefix iterator
+    iter, err := txn.NewPrefixIterator([]byte("prefix"), true)
+    if err != nil {
+        return err
+    }
+
+    // Iterate forward
+    for {
+        key, value, timestamp, ok := iter.Next()
+        if !ok {
+            break
+        }
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
+    }
+
+    // Change direction and iterate backward
+    err = iter.SetDirection(false)
+    if err != nil {
+        return err
+    }
+
+    for {
+        key, value, timestamp, ok := iter.Next()
+        if !ok {
+            break
+        }
+
+        fmt.Printf("Key: %s, Value: %s, Timestamp: %d\n", key, value, timestamp)
+    }
+
     return nil
 })
 ```
@@ -221,22 +340,6 @@ err = db.View(func(txn *wildcat.Txn) error {
 })
 ```
 
-### Prefix Iteration with Snapshot Isolation
-```go
-db.View(func(txn *wildcat.Txn) error {
-    iter := txn.NewIterator(nil, []byte("user:"))
-
-    for {
-        key, val, ts, ok := iter.Next()
-        if !ok {
-            break
-        }
-        fmt.Printf("Key=%s Value=%s Timestamp=%d\n", key, val, ts)
-    }
-
-    return nil
-})
-```
 
 ### Batch Operations
 You can perform multiple operations in a single transaction.
@@ -255,7 +358,27 @@ err := db.Update(func(txn *wildcat.Txn) error {
 })
 ```
 
-## Log Channel
+### Transaction Recovery
+```go
+// After reopening a database, you can access recovered transactions
+txn, err := db.GetTxn(transactionID)
+if err != nil {
+    // Transaction not found or error
+    return err
+}
+
+// Inspect the recovered transaction state
+fmt.Printf("Transaction %d status: committed=%v\n", txn.Id, txn.Committed)
+fmt.Printf("Write set: %v\n", txn.WriteSet)
+fmt.Printf("Delete set: %v\n", txn.DeleteSet)
+
+// You can commit or rollback the recovered transaction
+if !txn.Committed {
+    err = txn.Commit() // or txn.Rollback()
+}
+```
+
+### Log Channel
 Wildcat provides a log channel for real-time logging. You can set up a goroutine to listen for log messages.
 ```go
 // Create a log channel
@@ -298,7 +421,32 @@ wg.Wait() // Wait for the goroutine to finish
 defer db.Close()
 ```
 
-## Architecture Overview
+### Database Statistics
+Wildcat provides comprehensive statistics about database state
+```go
+stats := db.Stats()
+fmt.Println(stats)
+```
+
+This returns detailed information including
+- Configuration settings and tuning parameters
+- Active memtable size and entry count
+- Transaction counts and oldest active read timestamp
+- Level statistics and SSTable counts
+- ID generator states and WAL file counts
+- Compaction and flushing statistics
+
+### Force Flushing
+You can force a flush of all memtables to disk using the `Flush` method. This is useful for ensuring durability before performing critical operations.
+```go
+// Force all memtables to flush to SSTables
+err := db.ForceFlush()
+if err != nil {
+    // Handle error
+}
+```
+
+## Overview
 
 ### MVCC Model
 - Each key stores a timestamped version chain. The timestamps used are physical nanosecond timestamps (derived from `time.Now().UnixNano())`, providing a simple yet effective global ordering for versions.
@@ -314,11 +462,13 @@ defer db.Close()
 ### Memtable Lifecycle
 - Active memtable is swapped atomically when full.
 - Immutable memtables are flushed in background.
+- Skip list implementation with MVCC version chains for concurrent access.
 
 ### SSTables and Compaction
 - Immutable SSTables are organized into levels.
 - L1–L2 use size-tiered compaction.
 - L3+ use leveled compaction by key range.
+- Concurrent compaction with configurable maximum concurrency limits.
 - Compaction score is calculated using a hybrid formula `score = (levelSize / capacity) * 0.7 + (sstableCount / threshold) * 0.3` compaction is triggered when score > 1.0
 - Cooldown period enforced between compactions to prevent resource thrashing.
 - Compaction filters out redundant tombstones based on timestamp and overlapping range.
@@ -335,15 +485,40 @@ Each SSTable tracks the following main meta details:
 We only list the main meta data but there is more for internal use.
 
 ### SSTable Format
-SSTables are append-only and composed of
-- **Block 0** BSON-encoded metadata block containing structural fields (Min, Max, EntryCount, etc.)
-- **Block 1..N** Serialized BlockSet entries containing sorted key/value pairs
+SSTables are prefix and range optimized immutable BTree's.
+
+Structure
+- **KLog** `.klog` Contains BTree with key metadata and pointers to values
+- **VLog** `.vlog` Contains actual value data in append-only format
 
 During lookups
-- The Bloom filter is consulted first (if enabled)
-- Then Min/Max key range is checked
-- If eligible, the scan proceeds over BlockSet entries until the key is found
-- Actual values are retrieved from the VLog by block id
+- **Range check** Min/Max key range validation (skipped if outside bounds)
+- **Bloom filter** Consulted first if enabled (configurable false positive rate)
+- **BTree search** Key lookup in KLog BTree structure
+- **Value retrieval** Actual values retrieved from VLog using block IDs from KLog entries
+- **MVCC filtering** Only versions visible to read timestamp are returned
+
+### Compaction Policy / Strategy
+- **L1-L2** Size-tiered compaction for similar-sized SSTables
+- **L3+** Leveled compaction based on key range overlaps
+- **Concurrent execution** Configurable max concurrency with priority-based job scheduling
+- **Cooldown mechanism** Prevents thrashing with configurable cooldown periods
+
+#### Compaction Scoring Formula
+```
+score = (levelSize / capacity) * sizeWeight + (sstableCount / threshold) * countWeight
+```
+
+- **Default weight** sizeWeight=0.8, countWeight=0.2
+- **Trigger threshold** Compaction starts when score > 1.0
+- **Priority-based** Higher scores get priority in the compaction queue
+
+#### Compaction Process
+- **Job scheduling** Background process evaluates all levels every CompactorTickerInterval
+- **Priority queue** Jobs sorted by compaction score (highest first)
+- **Concurrent execution** Up to MaxCompactionConcurrency jobs run simultaneously
+- **Atomic operations** Source SSTables marked as merging, target level updated atomically
+- **Cleanup** Old SSTable files removed after successful compaction
 
 ### Concurrency Model
 - Wildcat uses lock-free structures where possible (e.g., atomic value swaps for memtables, atomic lru, queues, and more)
@@ -355,27 +530,193 @@ During lookups
 - No uncommitted state ever surfaces due to internal synchronization and timestamp-based visibility guarantees.
 
 ### Isolation Levels
-Wildcat supports the following transactional isolation levels:
-- **Snapshot Isolation** Transactions see a consistent snapshot of the database as of their start timestamp.
-- **Read Committed (implicit)** Readers only observe committed versions but do not see intermediate uncommitted writes.
+Wildcat supports ACID-compliant isolation
+- **Snapshot Isolation** Transactions see a consistent snapshot as of their start timestamp
+- **Read Committed** Readers observe only committed versions, never intermediate uncommitted writes
+- **No dirty reads** Timestamp-based MVCC prevents reading uncommitted data
+- **Repeatable reads** Within a transaction, reads are consistent to the transaction's timestamp
 
 ### Recoverability Guarantee Order
-- **WAL** All writes are first recorded to WAL atomically with full transaction details, including the transaction ID, ReadSet, WriteSet, and DeleteSet.
-- **Memtable** Writes are reflected in the in-memory memtable immediately upon commit.
-- **SSTables** Memtables are flushed to SSTables asynchronously via the flusher.
+Recovery process consists of several steps
+- **WAL scanning** All WAL files are processed in chronological order (sorted by timestamp)
+- **Transaction consolidation** Multiple WAL entries for same transaction ID are merged to final state
+- **State restoration** Final transaction states are applied to memtables and transaction lists
+- **Incomplete transaction preservation** Uncommitted transactions remain accessible via GetTxn(id)
 
-On crash
-- Wildcat rehydrates all transactions from the WAL, including active but uncommitted transactions, and reinstates their state in memory.
-- Recovered transactions can be accessed via `GetTxn(id)` for inspection, conflict resolution, or auditing.
-- The WAL is replayed in timestamp order, ensuring that the in-memory structures reflect a correct, consistent view of the last known good state.
-- Only transactions with durable WAL entries are considered recoverable.
+#### Durability Order
+**WAL** All writes recorded atomically with full transaction details (ReadSet, WriteSet, DeleteSet, commit status)
+**Memtable** Writes reflected in memory immediately upon commit
+**SSTables** Memtables flushed to SSTables asynchronously via background flusher
 
-This design guarantees durability, atomicity, and the ability to inspect past transactional state under failure recovery conditions.
-- WAL is replayed fully before memtable/SSTables are accessed.
-- Guarantees durability and atomicity for all committed transactions.
+#### Recovery Guarantees
+**Complete state restoration** All committed transactions are fully recovered
+**Incomplete transaction access** Uncommitted transactions can be inspected, committed, or rolled back
+**Timestamp consistency** WAL replay maintains correct timestamp ordering
+**Atomic recovery** Only transactions with durable WAL entries are considered recoverable
 
-## Motivation
+### Block Manager
+Wildcat's block manager provides low-level, high-performance file I/O with sophisticated features.
+
+#### Core
+**Direct I/O** Uses pread/pwrite system calls for atomic, position-independent operations
+**Block chaining** Supports multi-block data with automatic chain management
+**Free block management** Atomic queue-based allocation with block reuse
+**CRC verification** All blocks include CRC32 checksums for data integrity
+**Concurrent access** Thread-safe operations with lock-free design where possible
+
+#### Block Structure
+**Header validation** Magic number and version verification
+**Block metadata** Size, next block ID, and CRC checksums
+**Chain support** Automatic handling of data spanning multiple blocks
+**Free space tracking** Intelligent free block scanning and allocation
+
+#### Sync Options
+**SyncNone** No disk synchronization (fastest, least durable)
+**SyncFull** Synchronous writes with fdatasync (safest, slower)
+**SyncPartial** Background synchronization at configurable intervals (balanced)
+
+#### Recovery Features
+**Block validation** CRC verification on all block reads
+**Chain reconstruction** Automatic detection and handling of multi-block data
+**Free space recovery** Intelligent scanning to rebuild free block allocation table
+
+### LRU Cache
+Wildcat uses a sophisticated lock-free LRU cache for block manager handles.
+
+#### Advanced Features
+- **Lock-free design** Atomic operations with lazy eviction
+- **Anti-thrashing** Smart eviction with access pattern analysis
+- **Load factor awareness** Only evicts when near capacity (95%+)
+- **Emergency recovery** Automatic detection and recovery from stuck states
+- **Node reuse** Efficient memory management with node recycling
+
+#### Eviction Algorithm
+```bash
+evictionScore = accessWeight * accessCount + timeWeight * age
 ```
+- **Balanced approach** Considers both access frequency and recency
+- **Configurable weights** BlockManagerLRUAccesWeight controls the balance
+- **Gradual eviction** Evicts BlockManagerLRUEvictRatio portion when needed
+- **Emergency fallback** Aggressive cleanup when cache becomes unresponsive
+
+#### Performance Optimizations
+- **Batched processing** Processes eviction queue in controlled batches
+- **Progress tracking** Monitors cache operations to detect performance issues
+- **Concurrent-safe** Multiple threads can safely access cached resources
+- **Resource cleanup** Automatic resource management with eviction callbacks
+
+### Lock-Free Queue
+- **Michael & Scott algorithm** Industry-standard lock-free queue design
+- **ABA problem prevention** Proper pointer management and consistency checks
+- **Memory ordering** Atomic operations ensure proper synchronization
+- **High throughput** Supports millions of operations per second under contention
+
+### BTree
+Wildcat's BTree provides the foundation for SSTable key storage with advanced features for range queries and bidirectional iteration.
+
+#### Core
+- **Immutable design** Once written, BTrees are never modified, ensuring consistency
+- **Configurable order** SSTableBTreeOrder controls node size and tree depth
+- **Metadata storage** Supports arbitrary metadata attachment for SSTable information
+- **Block-based storage** Integrates seamlessly with the block manager for efficient I/O
+
+#### Advanced Features
+- **Bidirectional iteration** Full support for forward and reverse traversal
+- **Range queries** Efficient RangeIterator with start/end key bounds
+- **Prefix iteration** Optimized PrefixIterator for prefix-based searches
+- **Seek operations** Direct positioning to any key with Seek, SeekToFirst, SeekToLast
+- **BSON serialization** Automatic serialization/deserialization of nodes and values
+
+#### Iterator Capabilities
+```go
+// Multiple iterator types with consistent interface
+iterator, err := btree.Iterator(ascending)                      // Full tree iteration
+rangeIter, err := btree.RangeIterator(start, end, ascending)    // Range-bounded
+prefixIter, err := btree.PrefixIterator(prefix, ascending)      // Prefix-based
+
+// All iterators support
+iter.Next()           // Advance in configured direction
+iter.Prev()           // Move opposite to configured direction
+iter.Seek(key)        // Position at specific key
+iter.SetDirection()   // Change iteration direction
+iter.Valid()          // Check if positioned at valid entry
+```
+
+#### Performance Optimizations
+**Lazy loading** Nodes loaded on-demand from block storage
+**Efficient splitting** Automatic node splitting maintains balance
+**Leaf linking** Direct leaf-to-leaf pointers for faster iteration
+**Memory efficient** Minimal memory footprint with block-based storage
+
+#### Node Structure
+**Internal nodes** Store keys and child pointers for navigation
+**Leaf nodes** Store actual key-value pairs with next/prev links
+**BSON encoding** Consistent serialization format across all node types
+
+### SkipList
+Wildcat's SkipList serves as the core data structure for memtables, providing concurrent MVCC access with lock-free operations.
+
+#### MVCC Architecture
+**Version chains** Each key maintains a linked list of timestamped versions
+**Timestamp ordering** Physical nanosecond timestamps ensure global ordering
+**Lock-free access** Atomic operations enable concurrent reads and writes
+**Snapshot isolation** Readers see consistent snapshots at their read timestamp
+
+#### Concurrency Features
+**Non-blocking reads** Readers never block, even during concurrent writes
+**Atomic writes** CAS operations ensure thread-safe modifications
+**Version visibility** Timestamp-based filtering for MVCC consistency
+**Memory ordering** Proper atomic synchronization prevents race conditions
+
+#### Version Management
+```go
+type ValueVersion struct {
+    Data      []byte           // Actual value data
+    Timestamp int64            // Version timestamp
+    Type      ValueVersionType // Write or Delete marker
+    Next      *ValueVersion    // Link to previous version
+}
+```
+
+#### Advanced Operations
+**Put operations** Atomic insertion with version chaining
+**Delete operations** Tombstone markers with timestamp tracking
+**Get operations** Version-aware lookups with timestamp filtering
+**Range scanning** Efficient iteration over key ranges with MVCC consistency
+
+**Iterator Types**
+```go
+// Multiple specialized iterators
+iterator := skiplist.NewIterator(startKey, readTimestamp)
+rangeIter := skiplist.NewRangeIterator(start, end, readTimestamp)
+prefixIter := skiplist.NewPrefixIterator(prefix, readTimestamp)
+
+// All support bidirectional traversal with MVCC semantics
+iter.Next()    // Forward iteration with timestamp filtering
+iter.Prev()    // Backward iteration with timestamp filtering
+iter.Peek()    // Non-destructive current value inspection
+```
+
+#### Performance Characteristics
+- **O(log n)** average case for all operations
+- **Lock-free design** High concurrency with minimal contention
+- **Memory efficient** Optimized node structure with atomic pointers
+- **Skip probability** Configurable level distribution (p=0.25)
+- **Maximum levels** Bounded height (MaxLevel=16) for predictable performance
+
+#### MVCC Semantics
+- **Read consistency** Transactions see stable snapshots throughout their lifetime
+- **Write isolation** Concurrent writes don't interfere with each other
+- **Timestamp ordering** Later timestamps always override earlier ones
+- **Tombstone handling** Delete operations create versioned tombstone markers
+- **Garbage collection** Old versions naturally filtered by timestamp-based reads
+
+#### Memory Layout
+- **Node structure** Atomic forward pointers array + backward pointer
+- **Level generation** Probabilistic level assignment with geometric distribution
+- **Version chains** Per-key linked lists with atomic head pointers
+
+### Motivation
 My name is Alex Gaetano Padula, and I've spent the past several years fully immersed in one thing.. databases and storage engines. Not frameworks. Not trends. Just the raw, unforgiving internals of how data lives, moves, and survives.
 
 My journey began not with textbooks or formal training, but with pure curiosity. After writing my first database, CursusDB, to solve a real-time distributed problem, I couldn't stop experimenting. I dove into everything I could get my hands on.
@@ -396,7 +737,6 @@ I wanted to build a storage layer that didn't force you to choose between perfor
 Wildcat isn't just code I wrote. It's the distillation of every storage engine I've experimented with, every system I've torn down to understand, and every lesson I've learned through hands-on building.
 
 It's a culmination of countless experiments, sleepless nights, LOTS of COFFEE, and a relentless curiosity about how things actually work under the hood.
-```
 
-## Contributing
+### Contributing
 You can contribute, no problem!  Find a bug, optimization, refactor and submit a PR.  It will be reviewed.  You're only helping us all :)

--- a/serialize.go
+++ b/serialize.go
@@ -63,28 +63,6 @@ func (txn *Txn) deserializeTransaction(data []byte) error {
 	return nil
 }
 
-// serializeBlockSet uses BSON to serialize the block set
-func (bs *BlockSet) serializeBlockSet() ([]byte, error) {
-	// Serialize the block set to BSON
-	data, err := bson.Marshal(bs)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
-
-// deserializeBlockSet uses BSON to deserialize the block set
-func (bs *BlockSet) deserializeBlockSet(data []byte) error {
-	// Deserialize the block set from BSON
-	err := bson.Unmarshal(data, bs)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // serializeIDGeneratorState uses BSON to serialize the ID generator state
 func (idgs *IDGeneratorState) serializeIDGeneratorState() ([]byte, error) {
 	// Serialize the IDGeneratorState to BSON

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -135,54 +135,6 @@ func TestTxnSerialization(t *testing.T) {
 	// We don't compare mutex as it's not easily comparable
 }
 
-// TestBlockSetSerialization tests the serialization and deserialization of BlockSet
-func TestBlockSetSerialization(t *testing.T) {
-	// Create a test block set
-	original := &BlockSet{
-		Entries: []*KLogEntry{
-			{Key: []byte("key1"), ValueBlockID: 1, Timestamp: 1000},
-			{Key: []byte("key2"), ValueBlockID: 2, Timestamp: 2000},
-			{Key: []byte("key3"), ValueBlockID: 3, Timestamp: 3000},
-		},
-		Size: 12345,
-	}
-
-	// Serialize the block set
-	data, err := original.serializeBlockSet()
-	if err != nil {
-		t.Fatalf("Failed to serialize block set: %v", err)
-	}
-
-	// Deserialize the block set
-	result := &BlockSet{}
-	err = result.deserializeBlockSet(data)
-	if err != nil {
-		t.Fatalf("Failed to deserialize block set: %v", err)
-	}
-
-	// Compare the original and deserialized block set
-	if original.Size != result.Size {
-		t.Errorf("Size mismatch: expected %d, got %d", original.Size, result.Size)
-	}
-
-	if len(original.Entries) != len(result.Entries) {
-		t.Errorf("Entries length mismatch: expected %d, got %d", len(original.Entries), len(result.Entries))
-	} else {
-		for i, entry := range original.Entries {
-			resultEntry := result.Entries[i]
-			if !bytes.Equal(entry.Key, resultEntry.Key) {
-				t.Errorf("Entry %d Key mismatch: expected %v, got %v", i, entry.Key, resultEntry.Key)
-			}
-			if entry.ValueBlockID != resultEntry.ValueBlockID {
-				t.Errorf("Entry %d Value mismatch: expected %v, got %v", i, entry.ValueBlockID, resultEntry.ValueBlockID)
-			}
-			if entry.Timestamp != resultEntry.Timestamp {
-				t.Errorf("Entry %d Timestamp mismatch: expected %d, got %d", i, entry.Timestamp, resultEntry.Timestamp)
-			}
-		}
-	}
-}
-
 // TestSSTableSerializationError tests error handling in SSTable serialization
 func TestSSTableSerializationError(t *testing.T) {
 	// Create an invalid SSTable that would cause serialization to fail
@@ -201,16 +153,6 @@ func TestTxnSerializationError(t *testing.T) {
 	// Test deserialize with empty data
 	txn := &Txn{}
 	err := txn.deserializeTransaction([]byte{})
-	if err == nil {
-		t.Errorf("Expected error when deserializing empty data, got nil")
-	}
-}
-
-// TestBlockSetSerializationError tests error handling in BlockSet serialization
-func TestBlockSetSerializationError(t *testing.T) {
-	// Test deserialize with empty data
-	bs := &BlockSet{}
-	err := bs.deserializeBlockSet([]byte{})
 	if err == nil {
 		t.Errorf("Expected error when deserializing empty data, got nil")
 	}
@@ -235,10 +177,4 @@ func TestCorruptedDataDeserialization(t *testing.T) {
 		t.Errorf("Expected error when deserializing corrupted Txn data, got nil")
 	}
 
-	// Test BlockSet
-	bs := &BlockSet{}
-	err = bs.deserializeBlockSet(corruptedData)
-	if err == nil {
-		t.Errorf("Expected error when deserializing corrupted BlockSet data, got nil")
-	}
 }

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -1,0 +1,1236 @@
+// Package tree
+//
+// (C) Copyright Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tree
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go.mongodb.org/mongo-driver/bson"
+	"sort"
+)
+
+// BTree represents the tree.  An append only immutable B-tree implementation optimized for range and prefix iteration.
+type BTree struct {
+	blockManager BlockManager
+	rootBlockID  int64
+	order        int
+	metaBlockId  int64
+	extra        interface{}
+}
+
+// Metadata represents the metadata of the B-tree
+type Metadata struct {
+	RootBlockID int64
+	Order       int
+	Version     int
+	Extra       interface{}
+}
+
+// BlockManager interface matches your existing implementation
+type BlockManager interface {
+	Append(data []byte) (int64, error)
+	Read(blockID int64) ([]byte, int64, error)
+	Update(blockID int64, newData []byte) (int64, error)
+	Close() error
+}
+
+// Node represents a B-tree node
+type Node struct {
+	BlockID  int64
+	IsLeaf   bool
+	Keys     [][]byte
+	Values   []interface{} // Used in both leaf and internal nodes for consistency
+	Children []int64       // Block IDs of child nodes
+	Parent   int64         // Block ID of parent node (for efficient traversal)
+	NextLeaf int64         // Block ID of next leaf (for range iteration)
+	PrevLeaf int64         // Block ID of previous leaf (for bidirectional iteration)
+}
+
+// Iterator provides bidirectional iteration capabilities
+type Iterator struct {
+	btree       *BTree
+	currentNode *Node
+	currentIdx  int
+	stack       []iteratorFrame // Stack for tree traversal
+	ascending   bool
+	startKey    []byte
+	endKey      []byte
+	prefix      []byte
+	finished    bool
+}
+
+// iteratorFrame is used to keep track of the current node and index during iteration
+type iteratorFrame struct {
+	node *Node
+	idx  int
+}
+
+// Open retrieves/opens a btree instance.  Block manager should be opened with read/write!!
+func Open(blockManager BlockManager, order int, extraMeta interface{}) (*BTree, error) {
+	if order < 2 {
+		return nil, errors.New("order must be at least 2")
+	}
+
+	bt := &BTree{
+		blockManager: blockManager,
+		order:        order,
+		metaBlockId:  2, // Reserved for metadata
+		extra:        extraMeta,
+	}
+
+	// Try to load existing metadata first
+	metadata, err := bt.loadMetadata()
+	if err != nil {
+		// File doesn't exist or is empty - create new tree
+		return bt.createNewTree()
+	}
+
+	// Validate existing tree
+	if metadata.Order != order {
+		return nil, fmt.Errorf("existing tree has order %d, requested %d", metadata.Order, order)
+	}
+
+	bt.rootBlockID = metadata.RootBlockID
+
+	// Verify root exists and is valid
+	_, err = bt.loadNode(bt.rootBlockID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load existing root: %v", err)
+	}
+
+	return bt, nil
+}
+
+func (bt *BTree) createNewTree() (*BTree, error) {
+	// Create initial root node
+	root := &Node{
+		BlockID:  -1,
+		IsLeaf:   true,
+		Keys:     make([][]byte, 0),
+		Values:   make([]interface{}, 0),
+		Children: make([]int64, 0),
+		Parent:   -1,
+		NextLeaf: -1,
+		PrevLeaf: -1,
+	}
+
+	blockID, err := bt.storeNode(root)
+	if err != nil {
+		return nil, err
+	}
+
+	bt.rootBlockID = blockID
+
+	// Save metadata
+	err = bt.saveMetadata()
+	if err != nil {
+		return nil, err
+	}
+
+	return bt, nil
+}
+
+// loadNode loads a node from the block manager
+func (bt *BTree) loadMetadata() (*Metadata, error) {
+	data, _, err := bt.blockManager.Read(bt.metaBlockId)
+	if err != nil {
+		return nil, err // File doesn't exist or block 0 doesn't exist
+	}
+
+	var metadata Metadata
+	err = bson.Unmarshal(data, &metadata)
+	if err != nil {
+		return nil, err // Failed to unmarshal metadata
+	}
+
+	bt.extra = metadata.Extra // Attach extra metadata if needed
+
+	return &metadata, nil
+}
+
+// saveMetadata saves the metadata of the B-tree
+func (bt *BTree) saveMetadata() error {
+	metadata := Metadata{
+		RootBlockID: bt.rootBlockID,
+		Order:       bt.order,
+		Version:     1,
+		Extra:       bt.extra,
+	}
+
+	meta, err := bson.Marshal(&metadata)
+	if err != nil {
+		return err
+	}
+
+	// Save to block 0, or create it if it doesn't exist
+	_, err = bt.blockManager.Update(bt.metaBlockId, meta)
+	if err != nil {
+		// If update fails, try append (for first time)
+		_, err = bt.blockManager.Append(meta)
+	}
+
+	return err
+}
+
+// Put adds a key-value pair to the B-tree, updates if the key already exists
+func (bt *BTree) Put(key []byte, value interface{}) error {
+
+	if bt.rootBlockID == -1 {
+		return errors.New("tree not initialized")
+	}
+
+	root, err := bt.loadNode(bt.rootBlockID)
+	if err != nil {
+		return err
+	}
+
+	oldRootID := bt.rootBlockID
+
+	// If root is full, create new root
+	if bt.isNodeFull(root) {
+		newRoot := &Node{
+			BlockID:  -1, // Initialize as new node
+			IsLeaf:   false,
+			Keys:     make([][]byte, 0),
+			Values:   make([]interface{}, 0),
+			Children: []int64{bt.rootBlockID},
+			Parent:   -1,
+		}
+
+		newRootID, err := bt.storeNode(newRoot)
+		if err != nil {
+			return err
+		}
+
+		// Update the root reference
+		bt.rootBlockID = newRootID
+
+		// Update old root's parent
+		root.Parent = newRootID
+		if _, err := bt.storeNode(root); err != nil {
+			return err
+		}
+
+		// Split the old root (now child 0 of new root)
+		if err := bt.splitChild(newRoot, 0); err != nil {
+			return err
+		}
+	}
+
+	// If root changed, save metadata
+	if bt.rootBlockID != oldRootID {
+		err := bt.saveMetadata()
+		if err != nil {
+			return fmt.Errorf("failed to save metadata after root change: %v", err)
+		}
+	}
+
+	return bt.insertNonFull(bt.rootBlockID, key, value)
+}
+
+// Get finds a value by key
+func (bt *BTree) Get(key []byte) (interface{}, bool, error) {
+
+	return bt.get(bt.rootBlockID, key)
+}
+
+// RangeIterator returns an iterator for keys in the range [startKey, endKey]
+func (bt *BTree) RangeIterator(startKey, endKey []byte, ascending bool) (*Iterator, error) {
+
+	iter := &Iterator{
+		btree:     bt,
+		ascending: ascending,
+		stack:     make([]iteratorFrame, 0),
+		startKey:  make([]byte, len(startKey)),
+		endKey:    make([]byte, len(endKey)),
+		finished:  false,
+	}
+	copy(iter.startKey, startKey)
+	copy(iter.endKey, endKey)
+
+	var searchKey []byte
+	if ascending {
+		searchKey = startKey
+	} else {
+		searchKey = endKey
+	}
+
+	// Find starting position
+	node, idx, err := bt.findLeafPosition(searchKey)
+	if err != nil {
+		return nil, err
+	}
+
+	iter.currentNode = node
+	iter.currentIdx = idx
+
+	// Adjust position if needed
+	if ascending {
+
+		// For ascending, ensure we start at or after startKey
+		for iter.currentIdx < len(iter.currentNode.Keys) {
+			if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], startKey) >= 0 {
+				break
+			}
+			iter.currentIdx++
+		}
+
+		// If we've gone past the end of this node, try the next one
+		if iter.currentIdx >= len(iter.currentNode.Keys) {
+			if iter.currentNode.NextLeaf != -1 {
+				nextNode, err := iter.btree.loadNode(iter.currentNode.NextLeaf)
+				if err == nil {
+					iter.currentNode = nextNode
+					iter.currentIdx = 0
+
+					// Re-check bounds in the new node
+					for iter.currentIdx < len(iter.currentNode.Keys) {
+						if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], startKey) >= 0 {
+							break
+						}
+						iter.currentIdx++
+					}
+				} else {
+					iter.finished = true
+				}
+			} else {
+				iter.finished = true
+			}
+		}
+
+		// Check if we're already past the end key
+		if iter.currentIdx < len(iter.currentNode.Keys) && bytes.Compare(iter.currentNode.Keys[iter.currentIdx], endKey) > 0 {
+			iter.finished = true
+		}
+	} else {
+
+		// For descending, ensure we start at or before endKey
+		if iter.currentIdx >= len(iter.currentNode.Keys) {
+			iter.currentIdx = len(iter.currentNode.Keys) - 1
+		}
+		for iter.currentIdx >= 0 {
+			if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], endKey) <= 0 {
+				break
+			}
+			iter.currentIdx--
+		}
+		// If we've gone past the beginning of this node, try the previous one
+		if iter.currentIdx < 0 {
+			if iter.currentNode.PrevLeaf != -1 {
+				prevNode, err := iter.btree.loadNode(iter.currentNode.PrevLeaf)
+				if err == nil {
+					iter.currentNode = prevNode
+					iter.currentIdx = len(prevNode.Keys) - 1
+					// Re-check bounds in the new node
+					for iter.currentIdx >= 0 {
+						if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], endKey) <= 0 {
+							break
+						}
+						iter.currentIdx--
+					}
+				} else {
+					iter.finished = true
+				}
+			} else {
+				iter.finished = true
+			}
+		}
+
+		// Check if we're already past the start key
+		if iter.currentIdx >= 0 && bytes.Compare(iter.currentNode.Keys[iter.currentIdx], startKey) < 0 {
+			iter.finished = true
+		}
+	}
+
+	return iter, nil
+}
+
+// Iterator returns a general-purpose iterator that can seek to any position
+func (bt *BTree) Iterator(ascending bool) (*Iterator, error) {
+
+	iter := &Iterator{
+		btree:     bt,
+		ascending: ascending,
+		stack:     make([]iteratorFrame, 0),
+		finished:  false,
+	}
+
+	// Start at the appropriate end of the tree
+	if ascending {
+		// Find the leftmost (smallest) key
+		node, err := bt.findFirstLeaf()
+		if err != nil {
+			return nil, err
+		}
+		iter.currentNode = node
+		iter.currentIdx = 0
+	} else {
+		// Find the rightmost (largest) key
+		node, err := bt.findLastLeaf()
+		if err != nil {
+			return nil, err
+		}
+		iter.currentNode = node
+		if len(node.Keys) > 0 {
+			iter.currentIdx = len(node.Keys) - 1
+		} else {
+			iter.finished = true
+		}
+	}
+
+	return iter, nil
+}
+
+// Seek positions the iterator at the first key >= seekKey (for ascending) or <= seekKey (for descending)
+func (iter *Iterator) Seek(seekKey []byte) error {
+	if iter.btree == nil {
+		return errors.New("iterator not initialized")
+	}
+
+	// Find the leaf position for the seek key
+	node, idx, err := iter.btree.findLeafPosition(seekKey)
+	if err != nil {
+		return err
+	}
+
+	iter.currentNode = node
+	iter.currentIdx = idx
+	iter.finished = false
+
+	if iter.ascending {
+		// For ascending, ensure we're at or after seekKey
+		for iter.currentIdx < len(iter.currentNode.Keys) {
+			if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], seekKey) >= 0 {
+				break
+			}
+			iter.currentIdx++
+		}
+		// If we've gone past the end of this node, try the next one
+		if iter.currentIdx >= len(iter.currentNode.Keys) {
+			if iter.currentNode.NextLeaf != -1 {
+				nextNode, err := iter.btree.loadNode(iter.currentNode.NextLeaf)
+				if err == nil {
+					iter.currentNode = nextNode
+					iter.currentIdx = 0
+				} else {
+					iter.finished = true
+				}
+			} else {
+				iter.finished = true
+			}
+		}
+	} else {
+		// For descending, ensure we're at or before seekKey
+		if iter.currentIdx >= len(iter.currentNode.Keys) {
+			iter.currentIdx = len(iter.currentNode.Keys) - 1
+		}
+		for iter.currentIdx >= 0 {
+			if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], seekKey) <= 0 {
+				break
+			}
+			iter.currentIdx--
+		}
+
+		// If we've gone past the beginning of this node, try the previous one
+		if iter.currentIdx < 0 {
+			if iter.currentNode.PrevLeaf != -1 {
+				prevNode, err := iter.btree.loadNode(iter.currentNode.PrevLeaf)
+				if err == nil {
+					iter.currentNode = prevNode
+					iter.currentIdx = len(prevNode.Keys) - 1
+					// Re-check bounds in the new node
+					for iter.currentIdx >= 0 {
+						if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], seekKey) <= 0 {
+							break
+						}
+						iter.currentIdx--
+					}
+				} else {
+					iter.finished = true
+				}
+			} else {
+				iter.finished = true
+			}
+		}
+	}
+
+	return nil
+}
+
+// SeekToFirst positions the iterator at the first key in the tree
+func (iter *Iterator) SeekToFirst() error {
+	if iter.btree == nil {
+		return errors.New("iterator not initialized")
+	}
+
+	node, err := iter.btree.findFirstLeaf()
+	if err != nil {
+		return err
+	}
+
+	iter.currentNode = node
+	iter.currentIdx = 0
+	iter.finished = len(node.Keys) == 0
+	iter.ascending = true
+
+	return nil
+}
+
+// SeekToLast positions the iterator at the last key in the tree
+func (iter *Iterator) SeekToLast() error {
+	if iter.btree == nil {
+		return errors.New("iterator not initialized")
+	}
+
+	node, err := iter.btree.findLastLeaf()
+	if err != nil {
+		return err
+	}
+
+	iter.currentNode = node
+	if len(node.Keys) > 0 {
+		iter.currentIdx = len(node.Keys) - 1
+		iter.finished = false
+	} else {
+		iter.currentIdx = 0
+		iter.finished = true
+	}
+	iter.ascending = false
+
+	return nil
+}
+
+// SetDirection changes the iteration direction
+func (iter *Iterator) SetDirection(ascending bool) {
+	iter.ascending = ascending
+}
+
+func (iter *Iterator) Peek() ([]byte, interface{}, bool) {
+	if !iter.Valid() {
+		return nil, nil, false
+	}
+
+	key := iter.Key()
+	value := iter.Value()
+
+	return key, value, true
+}
+
+// Valid returns true if the iterator is positioned at a valid key
+func (iter *Iterator) Valid() bool {
+	if iter.finished || iter.currentNode == nil {
+		return false
+	}
+
+	// Check if we're within the bounds of the current node
+	if iter.ascending {
+		if iter.currentIdx >= len(iter.currentNode.Keys) {
+			return false
+		}
+	} else {
+		if iter.currentIdx < 0 || iter.currentIdx >= len(iter.currentNode.Keys) {
+			return false
+		}
+	}
+
+	// For range and prefix iterators, check bounds
+	if iter.currentIdx >= 0 && iter.currentIdx < len(iter.currentNode.Keys) {
+		key := iter.currentNode.Keys[iter.currentIdx]
+
+		// Check range bounds
+		if iter.endKey != nil && bytes.Compare(key, iter.endKey) > 0 {
+			return false
+		}
+		if iter.startKey != nil && bytes.Compare(key, iter.startKey) < 0 {
+			return false
+		}
+
+		// Check prefix
+		if iter.prefix != nil && !bytes.HasPrefix(key, iter.prefix) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Key returns the current key (without advancing the iterator)
+func (iter *Iterator) Key() []byte {
+	if !iter.Valid() {
+		return nil
+	}
+	return iter.currentNode.Keys[iter.currentIdx]
+}
+
+// Value returns the current value (without advancing the iterator)
+func (iter *Iterator) Value() interface{} {
+	if !iter.Valid() {
+		return nil
+	}
+	return iter.currentNode.Values[iter.currentIdx]
+}
+
+// NextItem returns the current key-value pair and advances the iterator (for backward compatibility)
+func (iter *Iterator) NextItem() ([]byte, interface{}, bool) {
+	if !iter.Valid() {
+		return nil, nil, false
+	}
+
+	key := iter.Key()
+	value := iter.Value()
+
+	// Advance iterator
+	iter.Next()
+
+	// Return the key-value we just read
+	return key, value, true
+}
+
+// Prev moves to the previous item (regardless of ascending flag)
+func (iter *Iterator) Prev() bool {
+	if iter.currentNode == nil {
+		return false
+	}
+
+	// Move to previous item
+	iter.currentIdx--
+
+	// If we've gone past the beginning of current node, try previous leaf
+	if iter.currentIdx < 0 {
+		if iter.currentNode.PrevLeaf != -1 {
+			prevNode, err := iter.btree.loadNode(iter.currentNode.PrevLeaf)
+			if err != nil {
+				iter.finished = true
+				return false
+			}
+			iter.currentNode = prevNode
+			iter.currentIdx = len(prevNode.Keys) - 1
+		} else {
+			iter.finished = true
+			return false
+		}
+	}
+
+	return iter.Valid()
+}
+
+// PrefixIterator returns an iterator for all keys with the given prefix
+func (bt *BTree) PrefixIterator(prefix []byte, ascending bool) (*Iterator, error) {
+
+	iter := &Iterator{
+		btree:     bt,
+		ascending: ascending,
+		stack:     make([]iteratorFrame, 0),
+		prefix:    make([]byte, len(prefix)),
+		finished:  false,
+	}
+	copy(iter.prefix, prefix)
+
+	// Find first key with prefix
+	node, idx, err := bt.findLeafPosition(prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	iter.currentNode = node
+	iter.currentIdx = idx
+
+	if ascending {
+
+		// Find first key that has the prefix
+		for {
+			if iter.currentIdx >= len(iter.currentNode.Keys) {
+
+				// Move to next leaf
+				if iter.currentNode.NextLeaf != -1 {
+					nextNode, err := iter.btree.loadNode(iter.currentNode.NextLeaf)
+					if err != nil {
+						iter.finished = true
+						break
+					}
+					iter.currentNode = nextNode
+					iter.currentIdx = 0
+				} else {
+					iter.finished = true
+					break
+				}
+			} else if bytes.HasPrefix(iter.currentNode.Keys[iter.currentIdx], prefix) {
+				break
+			} else if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], prefix) > 0 {
+
+				// We've gone past any possible prefix matches
+				iter.finished = true
+				break
+			} else {
+				iter.currentIdx++
+			}
+		}
+	} else {
+		// For descending, find the last key with prefix
+		// First, find the upper bound for the prefix
+		upperBound := make([]byte, len(prefix))
+		copy(upperBound, prefix)
+		if len(upperBound) > 0 {
+
+			// Increment the last byte to get upper bound
+			for i := len(upperBound) - 1; i >= 0; i-- {
+				if upperBound[i] < 255 {
+					upperBound[i]++
+					break
+				}
+				upperBound[i] = 0
+				if i == 0 {
+
+					// Overflow case
+					// We set to a very large value
+					upperBound = append(upperBound, 0)
+				}
+			}
+		}
+
+		// Find position for upper bound
+		node, idx, err = bt.findLeafPosition(upperBound)
+		if err != nil {
+			return nil, err
+		}
+		iter.currentNode = node
+		iter.currentIdx = idx - 1
+
+		// Find last key with prefix by going backward
+		for {
+			if iter.currentIdx < 0 {
+				// Move to previous leaf
+				if iter.currentNode.PrevLeaf != -1 {
+					prevNode, err := iter.btree.loadNode(iter.currentNode.PrevLeaf)
+					if err != nil {
+						iter.finished = true
+						break
+					}
+					iter.currentNode = prevNode
+					iter.currentIdx = len(prevNode.Keys) - 1
+				} else {
+					iter.finished = true
+					break
+				}
+			} else if bytes.HasPrefix(iter.currentNode.Keys[iter.currentIdx], prefix) {
+				break
+			} else if bytes.Compare(iter.currentNode.Keys[iter.currentIdx], prefix) < 0 {
+
+				// We've gone past any possible prefix matches
+				iter.finished = true
+				break
+			} else {
+				iter.currentIdx--
+			}
+		}
+	}
+
+	return iter, nil
+}
+
+// Next moves to the next item (direction depends on ascending flag)
+// Returns true if successful, false if no more items
+func (iter *Iterator) Next() bool {
+	if iter.finished || iter.currentNode == nil {
+		return false
+	}
+
+	if iter.ascending {
+		return iter.nextAscending()
+	}
+	return iter.nextDescending()
+}
+
+// HasNext checks if there are more items
+func (iter *Iterator) HasNext() bool {
+	return iter.Valid()
+}
+
+func (iter *Iterator) BTree() *BTree {
+	return iter.btree
+}
+
+// nextAcsending moves to the next item (for ascending iteration)
+func (iter *Iterator) nextAscending() bool {
+	if iter.currentNode == nil {
+		iter.finished = true
+		return false
+	}
+
+	// Move to next position
+	iter.currentIdx++
+
+	// Check if we have items in current node
+	if iter.currentIdx < len(iter.currentNode.Keys) {
+		// Check bounds and prefix in Valid() method
+		return iter.Valid()
+	}
+
+	// Move to next leaf
+	if iter.currentNode.NextLeaf != -1 {
+		nextNode, err := iter.btree.loadNode(iter.currentNode.NextLeaf)
+		if err != nil {
+			iter.finished = true
+			return false
+		}
+		iter.currentNode = nextNode
+		iter.currentIdx = 0
+		return iter.Valid()
+	}
+
+	iter.finished = true
+	return false
+}
+
+// nextDescending moves to the previous item (for descending iteration)
+func (iter *Iterator) nextDescending() bool {
+	if iter.currentNode == nil {
+		iter.finished = true
+		return false
+	}
+
+	// Move to previous position
+	iter.currentIdx--
+
+	// Check if we have items in current node
+	if iter.currentIdx >= 0 && iter.currentIdx < len(iter.currentNode.Keys) {
+		// Check bounds and prefix in Valid() method
+		return iter.Valid()
+	}
+
+	// Move to previous leaf
+	if iter.currentNode.PrevLeaf != -1 {
+		prevNode, err := iter.btree.loadNode(iter.currentNode.PrevLeaf)
+		if err != nil {
+			iter.finished = true
+			return false
+		}
+		iter.currentNode = prevNode
+		iter.currentIdx = len(prevNode.Keys) - 1
+		return iter.Valid()
+	}
+
+	iter.finished = true
+	return false
+}
+
+// get searches for a key in the B-tree
+func (bt *BTree) get(blockID int64, key []byte) (interface{}, bool, error) {
+	if blockID == -1 {
+		return nil, false, nil
+	}
+
+	node, err := bt.loadNode(blockID)
+	if err != nil {
+		return nil, false, err
+	}
+
+	idx := bt.findKeyIndex(node.Keys, key)
+
+	// Check if key exists at this position
+	if idx < len(node.Keys) && bytes.Equal(node.Keys[idx], key) {
+		// Key found - return the value directly
+		return node.Values[idx], true, nil
+	}
+
+	// Key not found at this level
+	if node.IsLeaf {
+		return nil, false, nil
+	}
+
+	// Search in appropriate child
+	return bt.get(node.Children[idx], key)
+}
+
+// findLeafPosition finds the leaf node and index for a given key
+func (bt *BTree) findLeafPosition(key []byte) (*Node, int, error) {
+	node, err := bt.loadNode(bt.rootBlockID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for !node.IsLeaf {
+		idx := bt.findKeyIndex(node.Keys, key)
+		node, err = bt.loadNode(node.Children[idx])
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	idx := bt.findKeyIndex(node.Keys, key)
+	return node, idx, nil
+}
+
+// findFirstLeaf finds the leftmost (first) leaf node in the tree
+func (bt *BTree) findFirstLeaf() (*Node, error) {
+	node, err := bt.loadNode(bt.rootBlockID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep going left until we reach a leaf
+	for !node.IsLeaf {
+		if len(node.Children) == 0 {
+			return nil, errors.New("internal node has no children")
+		}
+		node, err = bt.loadNode(node.Children[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+// findLastLeaf finds the rightmost (last) leaf node in the tree
+func (bt *BTree) findLastLeaf() (*Node, error) {
+	node, err := bt.loadNode(bt.rootBlockID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Keep going right until we reach a leaf
+	for !node.IsLeaf {
+		if len(node.Children) == 0 {
+			return nil, errors.New("internal node has no children")
+		}
+		node, err = bt.loadNode(node.Children[len(node.Children)-1])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return node, nil
+}
+
+// insertNonFull inserts a key-value pair into a non-full node
+func (bt *BTree) insertNonFull(blockID int64, key []byte, value interface{}) error {
+	node, err := bt.loadNode(blockID)
+	if err != nil {
+		return err
+	}
+
+	if node.IsLeaf {
+		// Insert into leaf
+		idx := bt.findKeyIndex(node.Keys, key)
+
+		// Check if key already exists
+		if idx < len(node.Keys) && bytes.Equal(node.Keys[idx], key) {
+
+			// Update existing key
+			node.Values[idx] = value
+		} else {
+
+			// Insert new key
+			node.Keys = append(node.Keys, nil)
+			node.Values = append(node.Values, nil)
+
+			// Shift elements
+			copy(node.Keys[idx+1:], node.Keys[idx:])
+			copy(node.Values[idx+1:], node.Values[idx:])
+
+			node.Keys[idx] = key
+			node.Values[idx] = value
+		}
+
+		_, err = bt.storeNode(node)
+		return err
+	}
+
+	// Internal node
+	idx := bt.findKeyIndex(node.Keys, key)
+	childID := node.Children[idx]
+
+	child, err := bt.loadNode(childID)
+	if err != nil {
+		return err
+	}
+
+	if bt.isNodeFull(child) {
+		err = bt.splitChild(node, idx)
+		if err != nil {
+			return err
+		}
+
+		node, err = bt.loadNode(blockID)
+		if err != nil {
+			return err
+		}
+
+		// After split, determine which child to insert into
+		if bytes.Compare(key, node.Keys[idx]) > 0 {
+			idx++
+		}
+	}
+
+	return bt.insertNonFull(node.Children[idx], key, value)
+}
+
+// splitChild splits a full child node into two nodes
+func (bt *BTree) splitChild(parent *Node, childIdx int) error {
+	child, err := bt.loadNode(parent.Children[childIdx])
+	if err != nil {
+		return err
+	}
+
+	mid := bt.order - 1
+	midKey := child.Keys[mid]
+	midValue := child.Values[mid]
+
+	// Create new right node
+	rightNode := &Node{
+		BlockID:  -1, // Initialize as new node
+		IsLeaf:   child.IsLeaf,
+		Keys:     make([][]byte, 0),
+		Values:   make([]interface{}, 0),
+		Children: make([]int64, 0),
+		Parent:   parent.BlockID,
+		NextLeaf: -1,
+		PrevLeaf: -1,
+	}
+
+	// Copy keys and values from mid+1 to end to right node
+	if mid+1 < len(child.Keys) {
+		rightNode.Keys = make([][]byte, len(child.Keys[mid+1:]))
+		copy(rightNode.Keys, child.Keys[mid+1:])
+		rightNode.Values = make([]interface{}, len(child.Values[mid+1:]))
+		copy(rightNode.Values, child.Values[mid+1:])
+	}
+
+	if child.IsLeaf {
+
+		// Update leaf links
+		rightNode.NextLeaf = child.NextLeaf
+		rightNode.PrevLeaf = child.BlockID
+	} else {
+		// For internal nodes, copy children from mid+1 to end
+		if mid+1 < len(child.Children) {
+			rightNode.Children = make([]int64, len(child.Children[mid+1:]))
+			copy(rightNode.Children, child.Children[mid+1:])
+		}
+	}
+
+	// Store right node to get its BlockID
+	rightBlockID, err := bt.storeNode(rightNode)
+	if err != nil {
+		return err
+	}
+
+	// Update leaf links with actual BlockID
+	if child.IsLeaf {
+		child.NextLeaf = rightBlockID
+		rightNode.PrevLeaf = child.BlockID
+
+		// Update next leafs prev pointer if it exists
+		if rightNode.NextLeaf != -1 {
+			nextLeaf, err := bt.loadNode(rightNode.NextLeaf)
+			if err == nil {
+				nextLeaf.PrevLeaf = rightBlockID
+				_, err = bt.storeNode(nextLeaf)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		// Update parent pointers for children of right node
+		for _, childID := range rightNode.Children {
+			if grandchild, err := bt.loadNode(childID); err == nil {
+				grandchild.Parent = rightBlockID
+				_, err = bt.storeNode(grandchild)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Truncate left node
+	if child.IsLeaf {
+
+		// For leaf nodes, keep keys 0 to mid (inclusive) - middle key stays in left
+		child.Keys = child.Keys[:mid+1]
+		child.Values = child.Values[:mid+1]
+	} else {
+
+		// For internal nodes, keep keys 0 to mid-1, children 0 to mid
+		child.Keys = child.Keys[:mid]
+		child.Values = child.Values[:mid]
+		child.Children = child.Children[:mid+1]
+	}
+
+	// Insert midKey into parent at the correct position
+	parent.Keys = append(parent.Keys, nil)
+	parent.Values = append(parent.Values, nil)
+	parent.Children = append(parent.Children, 0)
+
+	// Shift elements to make room for the new key
+	insertIdx := childIdx
+	copy(parent.Keys[insertIdx+1:], parent.Keys[insertIdx:])
+	copy(parent.Values[insertIdx+1:], parent.Values[insertIdx:])
+	copy(parent.Children[insertIdx+2:], parent.Children[insertIdx+1:])
+
+	// Insert the middle key and right child reference
+	parent.Keys[insertIdx] = midKey
+	parent.Values[insertIdx] = midValue
+	parent.Children[insertIdx+1] = rightBlockID
+
+	// Store all updated nodes
+	_, err = bt.storeNode(child)
+	if err != nil {
+		return err
+	}
+
+	_, err = bt.storeNode(rightNode)
+	if err != nil {
+		return err
+	}
+
+	_, err = bt.storeNode(parent)
+	return err
+}
+
+// isNodeFull checks if a node is full
+func (bt *BTree) isNodeFull(node *Node) bool {
+	return len(node.Keys) >= 2*bt.order-1
+}
+
+// findKeyIndex finds the index of the key in the sorted keys slice
+func (bt *BTree) findKeyIndex(keys [][]byte, key []byte) int {
+	return sort.Search(len(keys), func(i int) bool {
+		return bytes.Compare(keys[i], key) >= 0
+	})
+}
+
+// storeNode stores a node in the block manager
+func (bt *BTree) storeNode(node *Node) (int64, error) {
+	data, err := bt.serializeNode(node)
+	if err != nil {
+		return -1, err
+	}
+
+	if node.BlockID != -1 && node.BlockID != 0 {
+
+		// Update existing node
+		blockID, err := bt.blockManager.Update(node.BlockID, data)
+		if err != nil {
+			return -1, err
+		}
+
+		node.BlockID = blockID
+		return blockID, nil
+	}
+
+	blockID, err := bt.blockManager.Append(data)
+	if err != nil {
+		return -1, err
+	}
+
+	node.BlockID = blockID
+
+	return blockID, nil
+}
+
+// loadNode loads a node from the block manager
+func (bt *BTree) loadNode(blockID int64) (*Node, error) {
+	if blockID == -1 {
+		return nil, errors.New("invalid block ID")
+	}
+
+	data, _, err := bt.blockManager.Read(blockID)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := bt.deserializeNode(data)
+	if err != nil {
+		return nil, err
+	}
+
+	node.BlockID = blockID
+
+	return node, nil
+}
+
+func (bt *BTree) GetExtraMeta() interface{} {
+	return bt.extra
+}
+
+// serializeNode converts a Node into a byte array
+func (bt *BTree) serializeNode(node *Node) ([]byte, error) {
+	serialNode := struct {
+		IsLeaf   bool
+		Keys     [][]byte
+		Values   []interface{}
+		Children []int64
+		Parent   int64
+		NextLeaf int64
+		PrevLeaf int64
+	}{
+		IsLeaf:   node.IsLeaf,
+		Keys:     node.Keys,
+		Values:   node.Values,
+		Children: node.Children,
+		Parent:   node.Parent,
+		NextLeaf: node.NextLeaf,
+		PrevLeaf: node.PrevLeaf,
+	}
+
+	b, err := bson.Marshal(&serialNode)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// deserializeNode converts a byte array back into a Node
+func (bt *BTree) deserializeNode(data []byte) (*Node, error) {
+
+	var serialNode struct {
+		IsLeaf   bool
+		Keys     [][]byte
+		Values   []interface{}
+		Children []int64
+		Parent   int64
+		NextLeaf int64
+		PrevLeaf int64
+	}
+
+	err := bson.Unmarshal(data, &serialNode)
+	if err != nil {
+		return nil, err
+	}
+
+	node := &Node{
+		IsLeaf:   serialNode.IsLeaf,
+		Keys:     serialNode.Keys,
+		Values:   serialNode.Values,
+		Children: serialNode.Children,
+		Parent:   serialNode.Parent,
+		NextLeaf: serialNode.NextLeaf,
+		PrevLeaf: serialNode.PrevLeaf,
+	}
+
+	return node, nil
+}
+
+// Close closes the B-tree and its block manager
+func (bt *BTree) Close() error {
+
+	return bt.blockManager.Close()
+}

--- a/tree/tree_test.go
+++ b/tree/tree_test.go
@@ -1,0 +1,1802 @@
+// Package tree
+//
+// (C) Copyright Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package tree
+
+import (
+	"fmt"
+	"github.com/guycipher/wildcat/blockmanager"
+	"math/rand"
+	"os"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+)
+
+func TestBTreeBasicInsertSearch(t *testing.T) {
+	// Clean up any previous test file
+	_ = os.Remove("btree_test.db")
+
+	// Create block manager
+	bm, err := blockmanager.Open("btree_test.db", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
+	if err != nil {
+		t.Fatalf("failed to create block manager: %v", err)
+	}
+	defer func(bm *blockmanager.BlockManager) {
+		_ = bm.Close()
+	}(bm)
+	defer func() {
+		_ = os.Remove("btree_test.db")
+		if err != nil {
+
+		}
+	}()
+
+	// Create B-tree
+	tree, err := Open(bm, 3, nil)
+	if err != nil {
+		t.Fatalf("failed to create B-tree: %v", err)
+	}
+	defer func(tree *BTree) {
+		_ = tree.Close()
+	}(tree)
+
+	// Insert some key-value pairs
+	entries := map[string]string{
+		"apple":     "red",
+		"banana":    "yellow",
+		"cherry":    "red",
+		"date":      "brown",
+		"fig":       "purple",
+		"grape":     "green",
+		"kiwi":      "brown",
+		"lemon":     "yellow",
+		"mango":     "yellow",
+		"nectarine": "orange",
+		"orange":    "orange",
+		"papaya":    "orange",
+		"quince":    "yellow",
+	}
+
+	for k, v := range entries {
+		err := tree.Put([]byte(k), v)
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", k, err)
+		}
+	}
+
+	// Search and verify
+	for k, expected := range entries {
+		val, ok, err := tree.Get([]byte(k))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", k, err)
+			continue
+		}
+		if !ok {
+			t.Errorf("key %s not found", k)
+			continue
+		}
+		if val.(string) != expected {
+			t.Errorf("key %s: expected %s, got %s", k, expected, val.(string))
+		}
+	}
+}
+
+func setupTestBTree(t *testing.T, order int) (*BTree, func()) {
+	filename := fmt.Sprintf("btree_test_%d.db", order)
+	_ = os.Remove(filename)
+
+	bm, err := blockmanager.Open(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
+	if err != nil {
+		t.Fatalf("failed to create block manager: %v", err)
+	}
+
+	tree, err := Open(bm, order, nil)
+	if err != nil {
+		_ = bm.Close()
+		_ = os.Remove(filename)
+		t.Fatalf("failed to create B-tree: %v", err)
+	}
+
+	cleanup := func() {
+		_ = tree.Close()
+
+		_ = bm.Close()
+
+		_ = os.Remove(filename)
+	}
+
+	return tree, cleanup
+}
+
+func TestBTreeNodeStructure(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert some keys to create a simple structure
+	keys := []string{"e", "b", "h", "a", "d", "g", "i"}
+
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Get root node and examine its structure
+	rootNode, err := tree.loadNode(tree.rootBlockID)
+
+	if err != nil {
+		t.Fatalf("failed to load root node: %v", err)
+	}
+
+	t.Logf("Root node - IsLeaf: %v, Keys: %d, Children: %d",
+		rootNode.IsLeaf, len(rootNode.Keys), len(rootNode.Children))
+
+	for i, key := range rootNode.Keys {
+		t.Logf("  Key[%d]: %s", i, string(key))
+	}
+
+	if !rootNode.IsLeaf {
+		for i, childID := range rootNode.Children {
+			t.Logf("  Child[%d]: BlockID %d", i, childID)
+		}
+	}
+}
+
+func TestBTreeOrder2(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 2)
+	defer cleanup()
+
+	// Insert keys that will force splits
+	keys := []string{"m", "f", "g", "d", "k", "a", "h", "e", "s", "i", "r", "x", "c", "l", "n", "t", "u", "p"}
+
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Verify all keys
+	for _, key := range keys {
+		val, ok, err := tree.Get([]byte(key))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", key, err)
+		}
+		if !ok {
+			t.Errorf("key %s not found", key)
+		}
+		if val.(string) != key+"_value" {
+			t.Errorf("key %s: expected %s, got %s", key, key+"_value", val.(string))
+		}
+	}
+}
+
+func TestBTreeUpdateExistingKey(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	key := []byte("test")
+
+	// Insert initial value
+	err := tree.Put(key, "value1")
+	if err != nil {
+		t.Fatalf("initial insert failed: %v", err)
+	}
+
+	// Update with new value
+	err = tree.Put(key, "value2")
+	if err != nil {
+		t.Fatalf("update insert failed: %v", err)
+	}
+
+	// Verify updated value
+	val, ok, err := tree.Get(key)
+	if err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	if !ok {
+		t.Fatal("key not found after update")
+	}
+	if val.(string) != "value2" {
+		t.Errorf("expected value2, got %s", val.(string))
+	}
+}
+
+func TestBTreeLargeDataset(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 5)
+	defer cleanup()
+
+	// Insert 1000 sequential keys
+	numKeys := 1000
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("key_%06d", i)
+		value := fmt.Sprintf("value_%d", i)
+
+		err := tree.Put([]byte(key), value)
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Verify all keys
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("key_%06d", i)
+		expectedValue := fmt.Sprintf("value_%d", i)
+
+		val, ok, err := tree.Get([]byte(key))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", key, err)
+		}
+		if !ok {
+			t.Errorf("key %s not found", key)
+		}
+		if val.(string) != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, val.(string))
+		}
+	}
+}
+
+func TestBTreeRangeIteratorAscending(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert keys
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry", "fig", "grape"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Test range iteration from "cherry" to "fig"
+	iter, err := tree.RangeIterator([]byte("cherry"), []byte("fig"), true)
+	if err != nil {
+		t.Fatalf("failed to create range iterator: %v", err)
+	}
+
+	expectedKeys := []string{"cherry", "date", "elderberry", "fig"}
+	actualKeys := []string{}
+
+	for iter.Valid() {
+		key := iter.Key()
+		value := iter.Value()
+		actualKeys = append(actualKeys, string(key))
+		expectedValue := string(key) + "_value"
+		if value.(string) != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+		}
+		iter.Next()
+	}
+
+	if len(actualKeys) != len(expectedKeys) {
+		t.Errorf("expected %d keys, got %d", len(expectedKeys), len(actualKeys))
+	}
+
+	for i, expected := range expectedKeys {
+		if i >= len(actualKeys) || actualKeys[i] != expected {
+			t.Errorf("at index %d: expected %s, got %s", i, expected, actualKeys[i])
+		}
+	}
+}
+
+func TestBTreeRangeIteratorDescending(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert keys
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry", "fig", "grape"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Test descending range iteration from "fig" to "cherry"
+	iter, err := tree.RangeIterator([]byte("cherry"), []byte("fig"), false)
+	if err != nil {
+		t.Fatalf("failed to create range iterator: %v", err)
+	}
+
+	expectedKeys := []string{"fig", "elderberry", "date", "cherry"}
+	actualKeys := []string{}
+
+	for iter.Valid() {
+		key := iter.Key()
+		value := iter.Value()
+		actualKeys = append(actualKeys, string(key))
+		expectedValue := string(key) + "_value"
+		if value.(string) != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+		}
+		iter.Next()
+	}
+
+	if len(actualKeys) != len(expectedKeys) {
+		t.Errorf("expected %d keys, got %d", len(expectedKeys), len(actualKeys))
+	}
+
+	for i, expected := range expectedKeys {
+		if i >= len(actualKeys) || actualKeys[i] != expected {
+			t.Errorf("at index %d: expected %s, got %s", i, expected, actualKeys[i])
+		}
+	}
+}
+
+func TestBTreePrefixIteratorAscending(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert keys with common prefixes
+	keys := []string{"app", "apple", "application", "apply", "banana", "band", "bandana", "cat", "car", "card"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Test prefix iteration for "app"
+	iter, err := tree.PrefixIterator([]byte("app"), true)
+	if err != nil {
+		t.Fatalf("failed to create prefix iterator: %v", err)
+	}
+
+	expectedKeys := []string{"app", "apple", "application", "apply"}
+	actualKeys := []string{}
+
+	for iter.Valid() {
+		key := iter.Key()
+		value := iter.Value()
+		keyStr := string(key)
+
+		// Only collect keys that actually have the prefix
+		if len(keyStr) >= 3 && keyStr[:3] == "app" {
+			actualKeys = append(actualKeys, keyStr)
+			expectedValue := keyStr + "_value"
+			if value.(string) != expectedValue {
+				t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+			}
+		} else {
+			break // Stop when we reach keys without the prefix
+		}
+		iter.Next()
+	}
+
+	if len(actualKeys) != len(expectedKeys) {
+		t.Errorf("expected %d keys, got %d: %v", len(expectedKeys), len(actualKeys), actualKeys)
+	}
+
+	for i, expected := range expectedKeys {
+		if i >= len(actualKeys) || actualKeys[i] != expected {
+			t.Errorf("at index %d: expected %s, got %s", i, expected, actualKeys[i])
+		}
+	}
+}
+
+func TestBTreePrefixIteratorDescending(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert keys with common prefixes
+	keys := []string{"app", "apple", "application", "apply", "banana", "band", "bandana"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Test descending prefix iteration for "app"
+	iter, err := tree.PrefixIterator([]byte("app"), false)
+	if err != nil {
+		t.Fatalf("failed to create prefix iterator: %v", err)
+	}
+
+	expectedKeys := []string{"apply", "application", "apple", "app"}
+	actualKeys := []string{}
+
+	for iter.Valid() {
+		key := iter.Key()
+		value := iter.Value()
+		keyStr := string(key)
+
+		// Only collect keys that actually have the prefix
+		if len(keyStr) >= 3 && keyStr[:3] == "app" {
+			actualKeys = append(actualKeys, keyStr)
+			expectedValue := keyStr + "_value"
+			if value.(string) != expectedValue {
+				t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+			}
+		} else {
+			break // Stop when we reach keys without the prefix
+		}
+		iter.Next()
+	}
+
+	if len(actualKeys) != len(expectedKeys) {
+		t.Errorf("expected %d keys, got %d: %v", len(expectedKeys), len(actualKeys), actualKeys)
+	}
+
+	for i, expected := range expectedKeys {
+		if i >= len(actualKeys) || actualKeys[i] != expected {
+			t.Errorf("at index %d: expected %s, got %s", i, expected, actualKeys[i])
+		}
+	}
+}
+
+func TestBTreeSearchNonExistentKey(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert some keys
+	keys := []string{"apple", "banana", "cherry"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Search for non-existent key
+	val, ok, err := tree.Get([]byte("nonexistent"))
+	if err != nil {
+		t.Errorf("search should not error for non-existent key: %v", err)
+	}
+	if ok {
+		t.Error("search should return false for non-existent key")
+	}
+	if val != nil {
+		t.Errorf("search should return nil value for non-existent key, got: %v", val)
+	}
+}
+
+func TestBTreeInsertDuplicateValues(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert multiple keys with the same value
+	keys := []string{"key1", "key2", "key3"}
+	commonValue := "shared_value"
+
+	for _, key := range keys {
+		err := tree.Put([]byte(key), commonValue)
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Verify all keys have the same value
+	for _, key := range keys {
+		val, ok, err := tree.Get([]byte(key))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", key, err)
+		}
+		if !ok {
+			t.Errorf("key %s not found", key)
+		}
+		if val.(string) != commonValue {
+			t.Errorf("key %s: expected %s, got %s", key, commonValue, val.(string))
+		}
+	}
+}
+
+func TestBTreeDifferentValueTypes(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert different value types
+	testCases := []struct {
+		key   string
+		value interface{}
+	}{
+		{"string_key", "string_value"},
+		{"int_key", 42},
+		{"float_key", 3.14},
+		{"bool_key", true},
+		{"slice_key", []int{1, 2, 3}},
+	}
+
+	for _, tc := range testCases {
+		err := tree.Put([]byte(tc.key), tc.value)
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", tc.key, err)
+		}
+	}
+
+	// Verify all values
+	for _, tc := range testCases {
+		val, ok, err := tree.Get([]byte(tc.key))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", tc.key, err)
+		}
+		if !ok {
+			t.Errorf("key %s not found", tc.key)
+		}
+
+		if val == nil {
+			t.Errorf("key %s: got nil value", tc.key)
+		}
+	}
+}
+
+func TestBTreeConcurrentReads(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	numKeys := 100
+	for i := 0; i < numKeys; i++ {
+		key := fmt.Sprintf("key_%03d", i)
+		err := tree.Put([]byte(key), i)
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Perform concurrent reads
+	numGoroutines := 10
+	results := make(chan error, numGoroutines)
+
+	for g := 0; g < numGoroutines; g++ {
+		go func(goroutineID int) {
+			for i := int32(0); i < int32(numKeys); i++ {
+				key := fmt.Sprintf("key_%03d", i)
+				val, ok, err := tree.Get([]byte(key))
+				if err != nil {
+					results <- fmt.Errorf("goroutine %d: search failed for key %s: %v", goroutineID, key, err)
+					return
+				}
+				if !ok {
+					results <- fmt.Errorf("goroutine %d: key %s not found", goroutineID, key)
+					return
+				}
+				if val.(int32) != i {
+					results <- fmt.Errorf("goroutine %d: key %s: expected %d, got %v", goroutineID, key, i, val)
+					return
+				}
+			}
+			results <- nil
+		}(g)
+	}
+
+	// Wait for all goroutines to complete
+	for g := 0; g < numGoroutines; g++ {
+		if err := <-results; err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestBTreeInvalidOrder(t *testing.T) {
+	filename := "btree_invalid_test.db"
+	_ = os.Remove(filename)
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(filename)
+
+	bm, err := blockmanager.Open(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
+	if err != nil {
+		t.Fatalf("failed to create block manager: %v", err)
+	}
+	defer func(bm *blockmanager.BlockManager) {
+		_ = bm.Close()
+	}(bm)
+
+	// Try to create B-tree with invalid order
+	_, err = Open(bm, 1, nil)
+	if err == nil {
+		t.Error("expected error for order < 2")
+	}
+}
+
+func TestBTreeReverseSortedInsert(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert keys in reverse sorted order
+	keys := []string{"z", "y", "x", "w", "v", "u", "t", "s", "r", "q"}
+
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Verify all keys are searchable
+	for _, key := range keys {
+		val, ok, err := tree.Get([]byte(key))
+		if err != nil {
+			t.Errorf("search failed for key %s: %v", key, err)
+		}
+		if !ok {
+			t.Errorf("key %s not found", key)
+		}
+		if val.(string) != key+"_value" {
+			t.Errorf("key %s: expected %s, got %s", key, key+"_value", val.(string))
+		}
+	}
+
+	// Verify sorted iteration works correctly
+	iter, err := tree.RangeIterator([]byte("a"), []byte("z"), true)
+	if err != nil {
+		t.Fatalf("failed to create iterator: %v", err)
+	}
+
+	sortedKeys := make([]string, len(keys))
+	copy(sortedKeys, keys)
+	sort.Strings(sortedKeys)
+
+	actualKeys := []string{}
+	for iter.Valid() {
+		key := iter.Key()
+		actualKeys = append(actualKeys, string(key))
+		iter.Next()
+	}
+
+	if len(actualKeys) != len(sortedKeys) {
+		t.Errorf("expected %d keys, got %d", len(sortedKeys), len(actualKeys))
+	}
+
+	for i, expected := range sortedKeys {
+		if i >= len(actualKeys) || actualKeys[i] != expected {
+			t.Errorf("at index %d: expected %s, got %s", i, expected, actualKeys[i])
+		}
+	}
+}
+
+func TestBTreeGeneralIterator(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry", "fig", "grape"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	t.Run("AscendingIteration", func(t *testing.T) {
+		iter, err := tree.Iterator(true)
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		var result []string
+		for iter.Valid() {
+			key := iter.Key()
+			value := iter.Value()
+			result = append(result, string(key))
+			expectedValue := string(key) + "_value"
+			if value.(string) != expectedValue {
+				t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+			}
+			iter.Next()
+		}
+
+		expected := []string{"apple", "banana", "cherry", "date", "elderberry", "fig", "grape"}
+		if len(result) != len(expected) {
+			t.Errorf("expected %d keys, got %d", len(expected), len(result))
+		}
+		for i, exp := range expected {
+			if i >= len(result) || result[i] != exp {
+				t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+			}
+		}
+	})
+
+	t.Run("DescendingIteration", func(t *testing.T) {
+		iter, err := tree.Iterator(false)
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		var result []string
+		for iter.Valid() {
+			key := iter.Key()
+			value := iter.Value()
+			result = append(result, string(key))
+			expectedValue := string(key) + "_value"
+			if value.(string) != expectedValue {
+				t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+			}
+			iter.Next()
+		}
+
+		expected := []string{"grape", "fig", "elderberry", "date", "cherry", "banana", "apple"}
+		if len(result) != len(expected) {
+			t.Errorf("expected %d keys, got %d", len(expected), len(result))
+		}
+		for i, exp := range expected {
+			if i >= len(result) || result[i] != exp {
+				t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+			}
+		}
+	})
+}
+
+func TestBTreeIteratorSeek(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry", "fig", "grape"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	t.Run("SeekExistingKey", func(t *testing.T) {
+		iter, err := tree.Iterator(true)
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		// Seek to "date"
+		err = iter.Seek([]byte("date"))
+		if err != nil {
+			t.Fatalf("seek failed: %v", err)
+		}
+
+		if !iter.Valid() {
+			t.Fatal("iterator should be valid after seek")
+		}
+
+		key := iter.Key()
+		if string(key) != "date" {
+			t.Errorf("expected key 'date', got '%s'", string(key))
+		}
+
+		// Continue iteration from "date"
+		var result []string
+		for iter.Valid() {
+			key := iter.Key()
+			result = append(result, string(key))
+			iter.Next()
+		}
+
+		expected := []string{"date", "elderberry", "fig", "grape"}
+		if len(result) != len(expected) {
+			t.Errorf("expected %d keys, got %d", len(expected), len(result))
+		}
+		for i, exp := range expected {
+			if i >= len(result) || result[i] != exp {
+				t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+			}
+		}
+	})
+
+	t.Run("SeekNonExistentKey", func(t *testing.T) {
+		iter, err := tree.Iterator(true)
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		// Seek to "coconut" (should position at "date")
+		err = iter.Seek([]byte("coconut"))
+		if err != nil {
+			t.Fatalf("seek failed: %v", err)
+		}
+
+		if !iter.Valid() {
+			t.Fatal("iterator should be valid after seek")
+		}
+
+		key := iter.Key()
+		if string(key) != "date" {
+			t.Errorf("expected key 'date', got '%s'", string(key))
+		}
+	})
+
+	t.Run("SeekDescending", func(t *testing.T) {
+		iter, err := tree.Iterator(false)
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		// Seek to "date" in descending mode
+		err = iter.Seek([]byte("date"))
+		if err != nil {
+			t.Fatalf("seek failed: %v", err)
+		}
+
+		if !iter.Valid() {
+			t.Fatal("iterator should be valid after seek")
+		}
+
+		key := iter.Key()
+		if string(key) != "date" {
+			t.Errorf("expected key 'date', got '%s'", string(key))
+		}
+
+		// Continue iteration from "date" in descending order
+		var result []string
+		for iter.Valid() {
+			key := iter.Key()
+			result = append(result, string(key))
+			iter.Next()
+		}
+
+		expected := []string{"date", "cherry", "banana", "apple"}
+		if len(result) != len(expected) {
+			t.Errorf("expected %d keys, got %d", len(expected), len(result))
+		}
+		for i, exp := range expected {
+			if i >= len(result) || result[i] != exp {
+				t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+			}
+		}
+	})
+}
+
+func TestBTreeIteratorSeekToFirstLast(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry", "date", "elderberry"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	t.Run("SeekToFirst", func(t *testing.T) {
+		iter, err := tree.Iterator(false) // Start with descending
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		err = iter.SeekToFirst()
+		if err != nil {
+			t.Fatalf("SeekToFirst failed: %v", err)
+		}
+
+		if !iter.Valid() {
+			t.Fatal("iterator should be valid after SeekToFirst")
+		}
+
+		key := iter.Key()
+		if string(key) != "apple" {
+			t.Errorf("expected first key 'apple', got '%s'", string(key))
+		}
+	})
+
+	t.Run("SeekToLast", func(t *testing.T) {
+		iter, err := tree.Iterator(true) // Start with ascending
+		if err != nil {
+			t.Fatalf("failed to create iterator: %v", err)
+		}
+
+		err = iter.SeekToLast()
+		if err != nil {
+			t.Fatalf("SeekToLast failed: %v", err)
+		}
+
+		if !iter.Valid() {
+			t.Fatal("iterator should be valid after SeekToLast")
+		}
+
+		key := iter.Key()
+		if string(key) != "elderberry" {
+			t.Errorf("expected last key 'elderberry', got '%s'", string(key))
+		}
+	})
+}
+
+func TestBTreeIteratorDirectionChange(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry", "date"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	iter, err := tree.Iterator(true)
+	if err != nil {
+		t.Fatalf("failed to create iterator: %v", err)
+	}
+
+	// Start ascending, get first key
+	if !iter.Valid() {
+		t.Fatal("iterator should be valid at start")
+	}
+
+	key := iter.Key()
+	if string(key) != "apple" {
+		t.Errorf("expected first key 'apple', got '%s'", string(key))
+	}
+
+	iter.Next() // Move to "banana"
+
+	// Change to descending
+	iter.SetDirection(false)
+
+	// Should now go backwards from current position
+	var result []string
+	for iter.Valid() {
+		key := iter.Key()
+		result = append(result, string(key))
+		iter.Next()
+	}
+
+	// Note: After getting to "banana" and changing direction, we should get "banana", then "apple"
+	expected := []string{"banana", "apple"}
+	if len(result) != len(expected) {
+		t.Errorf("expected %d keys, got %d: %v", len(expected), len(result), result)
+	}
+	for i, exp := range expected {
+		if i >= len(result) || result[i] != exp {
+			t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+		}
+	}
+}
+
+func TestBTreeIteratorKeyValue(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	iter, err := tree.Iterator(true)
+	if err != nil {
+		t.Fatalf("failed to create iterator: %v", err)
+	}
+
+	// Test Key() and Value() methods without advancing
+	if !iter.Valid() {
+		t.Fatal("iterator should be valid at start")
+	}
+
+	key := iter.Key()
+	value := iter.Value()
+
+	if string(key) != "apple" {
+		t.Errorf("expected key 'apple', got '%s'", string(key))
+	}
+
+	if value.(string) != "apple_value" {
+		t.Errorf("expected value 'apple_value', got '%s'", value.(string))
+	}
+
+	// Key() and Value() should return the same thing when called again
+	key2 := iter.Key()
+	value2 := iter.Value()
+
+	if string(key2) != "apple" {
+		t.Errorf("expected key 'apple' on second call, got '%s'", string(key2))
+	}
+
+	if value2.(string) != "apple_value" {
+		t.Errorf("expected value 'apple_value' on second call, got '%s'", value2.(string))
+	}
+
+	// Advance iterator and check again
+	iter.Next()
+
+	if iter.Valid() {
+		key = iter.Key()
+		value = iter.Value()
+
+		if string(key) != "banana" {
+			t.Errorf("expected current key 'banana', got '%s'", string(key))
+		}
+
+		if value.(string) != "banana_value" {
+			t.Errorf("expected current value 'banana_value', got '%s'", value.(string))
+		}
+	}
+}
+
+func TestBTreeIteratorPrev(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry", "date"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	iter, err := tree.Iterator(true)
+	if err != nil {
+		t.Fatalf("failed to create iterator: %v", err)
+	}
+
+	// Seek to "cherry"
+	err = iter.Seek([]byte("cherry"))
+	if err != nil {
+		t.Fatalf("seek failed: %v", err)
+	}
+
+	// Go backward using Prev()
+	var result []string
+
+	// Add current key
+	if iter.Valid() {
+		result = append(result, string(iter.Key()))
+	}
+
+	// Go backwards
+	for iter.Prev() {
+		if iter.Valid() {
+			result = append(result, string(iter.Key()))
+		}
+	}
+
+	expected := []string{"cherry", "banana", "apple"}
+	if len(result) != len(expected) {
+		t.Errorf("expected %d keys, got %d: %v", len(expected), len(result), result)
+	}
+	for i, exp := range expected {
+		if i >= len(result) || result[i] != exp {
+			t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+		}
+	}
+}
+
+func TestBTreeIteratorEmptyTree(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Test iterator on empty tree
+	iter, err := tree.Iterator(true)
+	if err != nil {
+		t.Fatalf("failed to create iterator on empty tree: %v", err)
+	}
+
+	if iter.Valid() {
+		t.Error("iterator should not be valid on empty tree")
+	}
+
+	key := iter.Key()
+	if key != nil {
+		t.Error("key should be nil on empty tree")
+	}
+
+	value := iter.Value()
+	if value != nil {
+		t.Error("value should be nil on empty tree")
+	}
+
+	success := iter.Next()
+	if success {
+		t.Error("Next() should return false on empty tree")
+	}
+}
+
+func TestBTreeIteratorBackwardCompatibility(t *testing.T) {
+	tree, cleanup := setupTestBTree(t, 3)
+	defer cleanup()
+
+	// Insert test data
+	keys := []string{"apple", "banana", "cherry"}
+	for _, key := range keys {
+		err := tree.Put([]byte(key), key+"_value")
+		if err != nil {
+			t.Fatalf("insert failed for key %s: %v", key, err)
+		}
+	}
+
+	// Test backward compatibility with NextItem()
+	iter, err := tree.Iterator(true)
+	if err != nil {
+		t.Fatalf("failed to create iterator: %v", err)
+	}
+
+	var result []string
+	for {
+		key, value, ok := iter.NextItem()
+		if !ok {
+			break
+		}
+		result = append(result, string(key))
+		expectedValue := string(key) + "_value"
+		if value.(string) != expectedValue {
+			t.Errorf("key %s: expected %s, got %s", key, expectedValue, value.(string))
+		}
+	}
+
+	expected := []string{"apple", "banana", "cherry"}
+	if len(result) != len(expected) {
+		t.Errorf("expected %d keys, got %d", len(expected), len(result))
+	}
+	for i, exp := range expected {
+		if i >= len(result) || result[i] != exp {
+			t.Errorf("at index %d: expected %s, got %s", i, exp, result[i])
+		}
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	defer func() {
+		_ = os.RemoveAll("test.db")
+
+	}()
+
+	// Create new tree
+	bm1, _ := blockmanager.Open("test.db", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
+	tree1, _ := Open(bm1, 3, nil)
+	err := tree1.Put([]byte("key1"), "value1")
+	if err != nil {
+		t.Fatalf("failed to insert key1: %v", err)
+	}
+	_ = tree1.Close()
+
+	// Reopen existing tree
+	bm2, _ := blockmanager.Open("test.db", os.O_RDWR, 0644, blockmanager.SyncNone)
+	tree2, _ := Open(bm2, 3, nil)
+	defer func() {
+		_ = tree2.Close()
+		_ = bm2.Close()
+		_ = os.Remove("test.db")
+	}()
+	value, found, _ := tree2.Get([]byte("key1"))
+
+	if !found {
+		t.Error("key1 not found in reopened tree")
+	}
+
+	if value.(string) != "value1" {
+		t.Errorf("expected value1, got %s", value.(string))
+	}
+}
+
+func setupBenchBTree(b *testing.B, order int) (*BTree, func()) {
+	filename := fmt.Sprintf("bench_btree_%d_%d.db", order, time.Now().UnixNano())
+
+	bm, err := blockmanager.Open(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644, blockmanager.SyncNone)
+	if err != nil {
+		b.Fatalf("failed to create block manager: %v", err)
+	}
+
+	tree, err := Open(bm, order, nil)
+	if err != nil {
+		_ = bm.Close()
+		_ = os.Remove(filename)
+		b.Fatalf("failed to create B-tree: %v", err)
+	}
+
+	cleanup := func() {
+		_ = tree.Close()
+		_ = bm.Close()
+		_ = os.Remove(filename)
+	}
+
+	return tree, cleanup
+}
+
+func generateKeys(n int, keySize int) [][]byte {
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		key := make([]byte, keySize)
+		for j := 0; j < keySize; j++ {
+			key[j] = byte(rand.Intn(256))
+		}
+		keys[i] = key
+	}
+	return keys
+}
+
+func generateSequentialKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("key_%010d", i)
+		keys[i] = []byte(key)
+	}
+	return keys
+}
+
+func BenchmarkBTreeInsert(b *testing.B) {
+	orders := []int{3, 5, 10, 50, 100}
+	sizes := []int{1000, 10000, 100000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				keys := generateSequentialKeys(size)
+				values := make([]interface{}, size)
+				for i := 0; i < size; i++ {
+					values[i] = fmt.Sprintf("value_%d", i)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < size; j++ {
+						err := tree.Put(keys[j], values[j])
+						if err != nil {
+							b.Fatalf("failed to insert key %s: %v", keys[j], err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeInsertRandom(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				keys := generateKeys(size, 16) // 16-byte random keys
+				values := make([]interface{}, size)
+				for i := 0; i < size; i++ {
+					values[i] = fmt.Sprintf("value_%d", i)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < size; j++ {
+						err := tree.Put(keys[j], values[j])
+						if err != nil {
+							b.Fatalf("failed to insert key %x: %v", keys[j], err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeSearch(b *testing.B) {
+	orders := []int{3, 5, 10, 50}
+	sizes := []int{1000, 10000, 100000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				// Pre-populate the tree
+				keys := generateSequentialKeys(size)
+				for i := 0; i < size; i++ {
+					err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+					if err != nil {
+						b.Fatalf("failed to insert key %s: %v", keys[i], err)
+					}
+				}
+
+				// Random keys for searching
+				searchKeys := make([][]byte, b.N)
+				for i := 0; i < b.N; i++ {
+					searchKeys[i] = keys[rand.Intn(size)]
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					get, b2, err := tree.Get(searchKeys[i])
+					if err != nil {
+						b.Fatalf("failed to get key %s: %v", searchKeys[i], err)
+					}
+					if b2 {
+						if get == nil {
+							b.Fatalf("expected value for key %s, got nil", searchKeys[i])
+						}
+					} else {
+						b.Fatalf("key %s not found", searchKeys[i])
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeSearchMiss(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				// Pre-populate the tree
+				keys := generateSequentialKeys(size)
+				for i := 0; i < size; i++ {
+					err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+					if err != nil {
+						b.Fatalf("failed to insert key %s: %v", keys[i], err)
+					}
+				}
+
+				// Generate non-existent keys
+				missKeys := make([][]byte, b.N)
+				for i := 0; i < b.N; i++ {
+					key := fmt.Sprintf("miss_key_%d", i)
+					missKeys[i] = []byte(key)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					_, b2, err := tree.Get(missKeys[i])
+					if err != nil {
+						b.Fatalf("failed to get key %s: %v", missKeys[i], err)
+					}
+
+					if b2 {
+						b.Fatalf("expected key %s to be missing, but it was found", missKeys[i])
+					}
+
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeRangeIteration(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+	rangePercentages := []float64{0.1, 0.5, 1.0} // 10%, 50%, 100% of data
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			for _, rangePct := range rangePercentages {
+				name := fmt.Sprintf("Order%d/Size%d/Range%.0f%%", order, size, rangePct*100)
+				b.Run(name, func(b *testing.B) {
+					tree, cleanup := setupBenchBTree(b, order)
+					defer cleanup()
+
+					// Pre-populate the tree
+					keys := generateSequentialKeys(size)
+					for i := 0; i < size; i++ {
+						err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+						if err != nil {
+							b.Fatalf("failed to insert key %s: %v", keys[i], err)
+						}
+					}
+
+					rangeSize := int(float64(size) * rangePct)
+					startIdx := (size - rangeSize) / 2
+					endIdx := startIdx + rangeSize
+
+					startKey := keys[startIdx]
+					endKey := keys[endIdx-1]
+
+					b.ResetTimer()
+					b.ReportAllocs()
+
+					for i := 0; i < b.N; i++ {
+						iter, _ := tree.RangeIterator(startKey, endKey, true)
+						count := 0
+						for iter.Valid() {
+							iter.Key()
+							iter.Value()
+							iter.Next()
+							count++
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkBTreePrefixIteration(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				// Pre-populate with keys that have common prefixes
+				prefixes := []string{"user:", "product:", "order:", "invoice:", "session:"}
+				for i := 0; i < size; i++ {
+					prefix := prefixes[i%len(prefixes)]
+					key := fmt.Sprintf("%s%010d", prefix, i)
+					err := tree.Put([]byte(key), fmt.Sprintf("value_%d", i))
+					if err != nil {
+						b.Fatalf("failed to insert key %s: %v", key, err)
+					}
+				}
+
+				testPrefix := []byte("user:")
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					iter, _ := tree.PrefixIterator(testPrefix, true)
+					count := 0
+					for iter.Valid() {
+						iter.Key()
+						iter.Value()
+						iter.Next()
+						count++
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeFullIteration(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000, 100000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			for _, ascending := range []bool{true, false} {
+				direction := "Asc"
+				if !ascending {
+					direction = "Desc"
+				}
+				name := fmt.Sprintf("Order%d/Size%d/%s", order, size, direction)
+				b.Run(name, func(b *testing.B) {
+					tree, cleanup := setupBenchBTree(b, order)
+					defer cleanup()
+
+					// Pre-populate the tree
+					keys := generateSequentialKeys(size)
+					for i := 0; i < size; i++ {
+						err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+						if err != nil {
+							b.Fatalf("failed to insert key %s: %v", keys[i], err)
+						}
+					}
+
+					b.ResetTimer()
+					b.ReportAllocs()
+
+					for i := 0; i < b.N; i++ {
+						iter, _ := tree.Iterator(ascending)
+						count := 0
+						for iter.Valid() {
+							iter.Key()
+							iter.Value()
+							iter.Next()
+							count++
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+func BenchmarkBTreeIteratorSeek(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				// Pre-populate the tree
+				keys := generateSequentialKeys(size)
+				for i := 0; i < size; i++ {
+					err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+					if err != nil {
+						b.Fatalf("failed to insert key %s: %v", keys[i], err)
+					}
+				}
+
+				// Random seek targets
+				seekKeys := make([][]byte, b.N)
+				for i := 0; i < b.N; i++ {
+					seekKeys[i] = keys[rand.Intn(size)]
+				}
+
+				iter, _ := tree.Iterator(true)
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					err := iter.Seek(seekKeys[i])
+					if err != nil {
+						b.Fatalf("failed to seek to key %s: %v", seekKeys[i], err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeMixed(b *testing.B) {
+	orders := []int{5, 10, 50}
+	sizes := []int{1000, 10000}
+
+	for _, order := range orders {
+		for _, size := range sizes {
+			name := fmt.Sprintf("Order%d/Size%d", order, size)
+			b.Run(name, func(b *testing.B) {
+				tree, cleanup := setupBenchBTree(b, order)
+				defer cleanup()
+
+				// Pre-populate half the tree
+				halfSize := size / 2
+				keys := generateSequentialKeys(size)
+				for i := 0; i < halfSize; i++ {
+					err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+					if err != nil {
+						b.Fatalf("failed to insert key %s: %v", keys[i], err)
+					}
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				for i := 0; i < b.N; i++ {
+					// Mix of operations
+					opType := i % 3
+					switch opType {
+					case 0: // Insert
+						idx := halfSize + (i % halfSize)
+						if idx < size {
+							err := tree.Put(keys[idx], fmt.Sprintf("value_%d", idx))
+							if err != nil {
+								b.Fatalf("failed to insert key %s: %v", keys[idx], err)
+							}
+						}
+					case 1: // Search
+						idx := i % halfSize
+						get, b2, err := tree.Get(keys[idx])
+						if err != nil {
+							b.Fatalf("failed to get key %s: %v", keys[idx], err)
+						}
+						if b2 {
+							if get == nil {
+								b.Fatalf("expected value for key %s, got nil", keys[idx])
+							}
+						} else {
+							b.Fatalf("key %s not found", keys[idx])
+						}
+					case 2: // Short iteration
+						iter, _ := tree.Iterator(true)
+						count := 0
+						for iter.Valid() && count < 10 {
+							iter.Key()
+							iter.Value()
+							iter.Next()
+							count++
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkBTreeKeySize(b *testing.B) {
+	keySizes := []int{8, 16, 32, 64, 128, 256}
+	size := 10000
+	order := 10
+
+	for _, keySize := range keySizes {
+		name := fmt.Sprintf("KeySize%d", keySize)
+		b.Run(name, func(b *testing.B) {
+			tree, cleanup := setupBenchBTree(b, order)
+			defer cleanup()
+
+			keys := generateKeys(size, keySize)
+			values := make([]interface{}, size)
+			for i := 0; i < size; i++ {
+				values[i] = fmt.Sprintf("value_%d", i)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < size; j++ {
+					err := tree.Put(keys[j], values[j])
+					if err != nil {
+						b.Fatalf("failed to insert key %x: %v", keys[j], err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkBTreeConcurrentReads(b *testing.B) {
+	tree, cleanup := setupBenchBTree(b, 10)
+	defer cleanup()
+
+	// Pre-populate the tree
+	size := 10000
+	keys := generateSequentialKeys(size)
+	for i := 0; i < size; i++ {
+		err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+		if err != nil {
+			b.Fatalf("failed to insert key %s: %v", keys[i], err)
+		}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			key := keys[rand.Intn(size)]
+			get, b2, err := tree.Get(key)
+			if err != nil {
+				b.Fatalf("failed to get key %s: %v", key, err)
+			}
+
+			if b2 {
+				if get == nil {
+					b.Fatalf("expected value for key %s, got nil", key)
+				}
+			} else {
+				b.Fatalf("key %s not found", key)
+			}
+		}
+	})
+}
+
+func BenchmarkBTreeDeepTree(b *testing.B) {
+	tree, cleanup := setupBenchBTree(b, 3) // Small order = deep tree
+	defer cleanup()
+
+	size := 10000
+	keys := generateSequentialKeys(size)
+
+	// Pre-populate
+	for i := 0; i < size; i++ {
+		err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+		if err != nil {
+			b.Fatalf("failed to insert key %s: %v", keys[i], err)
+		}
+	}
+
+	searchKeys := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		searchKeys[i] = keys[rand.Intn(size)]
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		get, b2, err := tree.Get(searchKeys[i])
+		if err != nil {
+			b.Fatalf("failed to get key %s: %v", searchKeys[i], err)
+		}
+		if b2 {
+			if get == nil {
+				b.Fatalf("expected value for key %s, got nil", searchKeys[i])
+			}
+		} else {
+			b.Fatalf("key %s not found", searchKeys[i])
+		}
+	}
+}
+
+func BenchmarkBTreeWideTree(b *testing.B) {
+	tree, cleanup := setupBenchBTree(b, 100) // Large order = wide tree
+	defer cleanup()
+
+	size := 10000
+	keys := generateSequentialKeys(size)
+
+	// Pre-populate
+	for i := 0; i < size; i++ {
+		err := tree.Put(keys[i], fmt.Sprintf("value_%d", i))
+		if err != nil {
+			b.Fatalf("failed to insert key %s: %v", keys[i], err)
+		}
+	}
+
+	searchKeys := make([][]byte, b.N)
+	for i := 0; i < b.N; i++ {
+		searchKeys[i] = keys[rand.Intn(size)]
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		get, b2, err := tree.Get(searchKeys[i])
+		if err != nil {
+			b.Fatalf("failed to get key %s: %v", searchKeys[i], err)
+		}
+
+		if b2 {
+			if get == nil {
+				b.Fatalf("expected value for key %s, got nil", searchKeys[i])
+			}
+		} else {
+			b.Fatalf("key %s not found", searchKeys[i])
+		}
+	}
+}
+
+func BenchmarkBTreeActualMemoryFootprint(b *testing.B) {
+	tree, cleanup := setupBenchBTree(b, 10)
+	defer cleanup()
+
+	// Insert data once
+	for i := 0; i < 10000; i++ {
+		key := fmt.Sprintf("key_%010d", i)
+		err := tree.Put([]byte(key), fmt.Sprintf("value_%d", i))
+		if err != nil {
+			b.Fatalf("failed to insert key %s: %v", key, err)
+		}
+	}
+
+	// Force GC to clean up temporary allocations
+	runtime.GC()
+	runtime.GC()
+
+	// Now measure what's actually in memory
+	var m1, m2 runtime.MemStats
+	runtime.ReadMemStats(&m1)
+
+	// Do one operation to see incremental cost
+	_, _, err := tree.Get([]byte("key_0000005000"))
+	if err != nil {
+		b.Fatalf("failed to get key: %v", err)
+	}
+
+	runtime.ReadMemStats(&m2)
+
+	b.ReportMetric(float64(m2.Alloc-m1.Alloc), "bytes/op")
+}

--- a/txn_test.go
+++ b/txn_test.go
@@ -25,14 +25,12 @@ import (
 )
 
 func TestTxn_BasicOperations(t *testing.T) {
+
 	// Create a temporary directory for the test
 	dir, err := os.MkdirTemp("", "db_txn_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -139,9 +137,6 @@ func TestTxn_Rollback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -218,9 +213,6 @@ func TestTxn_Isolation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -305,9 +297,6 @@ func TestTxn_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -387,9 +376,6 @@ func TestTxn_ConcurrentOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -492,9 +478,6 @@ func TestTxn_WALRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)
@@ -611,10 +594,6 @@ func TestTxn_DeleteTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
-	defer func(path string) {
-		_ = os.RemoveAll(path)
-
-	}(dir)
 
 	// Create a log channel
 	logChan := make(chan string, 100)


### PR DESCRIPTION
Replacing sorted array like block layout for sstables for btree.  Most of code as been refactored to allow for this change.  Wildcat is now write and read optimized.